### PR TITLE
ci(link-checker): update base URL to include www and refine link checking arguments

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
 
     env:
-      BASE_URL: https://filecoin.cloud
+      BASE_URL: https://www.filecoin.cloud
 
     steps:
       - name: Check out code
@@ -25,13 +25,16 @@ jobs:
         with:
           args: |
             --accept 100..=103,200..=299,403,429
-            --base ${{ env.BASE_URL }}
+            --base-url ${{ env.BASE_URL }}
             --retry-wait-time 3
             --max-retries 3
             --timeout 30
             --user-agent "Mozilla/5.0 (compatible; LinkChecker/1.0)"
             --verbose
-            "src/**/*.{md,tsx,ts}"
+            --no-progress
+            "src/**/*.md"
+            "src/**/*.tsx"
+            "src/**/*.ts"
           format: markdown
           output: ./lychee-report.md
           fail: false


### PR DESCRIPTION
## 📝 Description

This PR fixes the link-checker action:
- Changed BASE_URL from https://filecoin.cloud to https://www.filecoin.cloud for accurate linking
- Updated --base to --base-url for compatibility
- Added --no-progress flag to suppress output noise
- Split file patterns into separate lines for clarity and maintainability