### PR TITLE
FOC Building Blocks - Landing Page

### DIFF
--- a/src/app/hidden/(homepage)/data/filecoinOnchainCloudProducts.ts
+++ b/src/app/hidden/(homepage)/data/filecoinOnchainCloudProducts.ts
@@ -1,17 +1,14 @@
-// import type { SimpleCardData } from '@/components/SimpleCard'
-
-type SimpleCardData = {
-  title: string
-  description: string
-  cta: {
-    href: string
-    text: string
-  }
-}
+import type { SimpleCardData } from '@filecoin-foundation/ui-filecoin/SimpleCard'
 
 export const filecoinOnchainCloudProducts = [
   {
-    title: 'Filecoin Warm Storage',
+    title: 'Service Providers',
+    description:
+      'A global network of operators running Filecoin Onchain Cloud nodes delivering resilient, high-availability storage infrastructure.',
+    cta: { href: '#todo', text: 'Learn more' },
+  },
+  {
+    title: 'Warm Storage',
     description:
       'A storage layer that keeps data accessible while maintaining verifiable persistence across the Filecoin network. Powered by onchain contracts for storage and payments.',
     cta: {
@@ -36,11 +33,5 @@ export const filecoinOnchainCloudProducts = [
       href: '#todo',
       text: 'Learn more',
     },
-  },
-  {
-    title: 'Service Providers',
-    description:
-      'A global network of operators running Filecoin Onchain Cloud nodes delivering resilient, high-availability storage infrastructure.',
-    cta: { href: '#todo', text: 'Learn more' },
   },
 ] as const satisfies Array<SimpleCardData>

--- a/src/app/hidden/(homepage)/page.tsx
+++ b/src/app/hidden/(homepage)/page.tsx
@@ -5,11 +5,10 @@ import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
 import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
 import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
 
-// import { SimpleCard } from '@filecoin-foundation/ui-filecoin/SimpleCard'
-
 import { Button } from '@/components/Button'
 import { Faq } from '@/components/Faq'
 import { LinkCard } from '@/components/LinkCard'
+import { SimpleCard } from '@/components/SimpleCard'
 
 import { buildersLogos } from './data/buildersLogos'
 import { developerResources } from './data/developerResources'
@@ -100,22 +99,18 @@ export default function HiddenHomepage() {
       <PageSection backgroundVariant="dark">
         <SectionContent
           centerCTA
-          title="Compose the Building Blocks"
+          title="FOC Building Blocks"
           description="Modular services you can mix, match, and deploy, all built for openness, performance, and control."
         >
           <CardGrid as="ul" variant="smTwoXlFourWider">
             {filecoinOnchainCloudProducts.map(({ title, description, cta }) => (
-              <div key={title}>
-                <div>{title}</div>
-                <div>{description}</div>
-              </div>
-              // <SimpleCard
-              //   key={title}
-              //   as="li"
-              //   title={title}
-              //   description={description}
-              //   cta={cta}
-              // />
+              <SimpleCard
+                key={title}
+                as="li"
+                title={title}
+                description={description}
+                cta={cta}
+              />
             ))}
           </CardGrid>
         </SectionContent>

--- a/src/components/CTALink.tsx
+++ b/src/components/CTALink.tsx
@@ -1,0 +1,22 @@
+import {
+  CTALink as SharedCTALink,
+  type CTALinkProps as SharedCTALinkProps,
+} from '@filecoin-foundation/ui-filecoin/CTALink'
+import Link from 'next/link'
+
+import { BASE_DOMAIN } from '@/constants/siteMetadata'
+
+export type CTALinkProps = Omit<
+  SharedCTALinkProps,
+  'baseDomain' | 'InternalLinkComponent'
+>
+
+export function CTALink(props: CTALinkProps) {
+  return (
+    <SharedCTALink
+      {...props}
+      baseDomain={BASE_DOMAIN}
+      InternalLinkComponent={Link}
+    />
+  )
+}

--- a/src/components/SimpleCard.tsx
+++ b/src/components/SimpleCard.tsx
@@ -1,0 +1,14 @@
+import {
+  SimpleCard as SharedSimpleCard,
+  type SimpleCardProps as SharedSimpleCardProps,
+} from '@filecoin-foundation/ui-filecoin/SimpleCard'
+
+import { CTALink } from './CTALink'
+
+export type { SimpleCardData } from '@filecoin-foundation/ui-filecoin/SimpleCard'
+
+export type SimpleCardProps = Omit<SharedSimpleCardProps, 'CTALinkComponent'>
+
+export function SimpleCard(props: SimpleCardProps) {
+  return <SharedSimpleCard {...props} CTALinkComponent={CTALink} />
+}


### PR DESCRIPTION
## 📝 Description

Migrates the FOC Building Blocks section from placeholder divs to the reusable SimpleCard component from the ui-filecoin library.

[[UXIT-3540]](https://www.notion.so/filecoin/Filecoin-Onchain-Cloud-FOC-Building-Blocks-Landing-Page-29a7631f282580918686c4d60c9ae8f1?v=11f7631f2825804bad28000c3d965614&source=copy_link)

## 📸 Screenshots
<img width="1676" height="623" alt="Screenshot 2025-10-30 at 10 17 35" src="https://github.com/user-attachments/assets/e2f1e8f4-9509-48e4-9eec-3ad0d6392c21" />

