### PR TITLE
Add Phase component and phases data for project timeline display

### DIFF
--- a/src/app/hidden/(homepage)/data/buildPhases.ts
+++ b/src/app/hidden/(homepage)/data/buildPhases.ts
@@ -1,0 +1,41 @@
+import type { PhaseProps } from '@/components/Phase'
+
+export const buildPhases: Array<
+  Pick<PhaseProps, 'date' | 'title' | 'description' | 'status'>
+> = [
+  {
+    date: 'Apr 2025',
+    title: 'Phase I',
+    description:
+      'Lorem ipsum dolor sit amet consectetur. Feugiat non pulvinar senectus bibendum vitae.',
+    status: 'completed',
+  },
+  {
+    date: 'Oct 2025',
+    title: 'Phase II',
+    description:
+      'Lorem ipsum dolor sit amet consectetur. Feugiat non pulvinar senectus bibendum vitae.',
+    status: 'current',
+  },
+  {
+    date: 'Nov 2025',
+    title: 'Phase III',
+    description:
+      'Lorem ipsum dolor sit amet consectetur. Feugiat non pulvinar senectus bibendum vitae.',
+    status: 'upcoming',
+  },
+  {
+    date: 'Jan 2026',
+    title: 'Phase IV',
+    description:
+      'Lorem ipsum dolor sit amet consectetur. Feugiat non pulvinar senectus bibendum vitae.',
+    status: 'upcoming',
+  },
+  {
+    date: 'Sep 2026',
+    title: 'Phase V',
+    description:
+      'Lorem ipsum dolor sit amet consectetur. Feugiat non pulvinar senectus bibendum vitae.',
+    status: 'upcoming',
+  },
+]

--- a/src/app/hidden/(homepage)/page.tsx
+++ b/src/app/hidden/(homepage)/page.tsx
@@ -8,9 +8,11 @@ import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
 import { Button } from '@/components/Button'
 import { Faq } from '@/components/Faq'
 import { LinkCard } from '@/components/LinkCard'
+import { Phase } from '@/components/Phase'
 import { SimpleCard } from '@/components/SimpleCard'
 
 import { buildersLogos } from './data/buildersLogos'
+import { buildPhases } from './data/buildPhases'
 import { developerResources } from './data/developerResources'
 import { faqs } from './data/faqs'
 import { filecoinOnchainCloudProducts } from './data/filecoinOnchainCloudProducts'
@@ -125,7 +127,29 @@ export default function HiddenHomepage() {
               Join the community
             </Button>
           }
-        />
+        >
+          <div className="flex flex-col sm:flex-row flex-wrap xl:flex-nowrap">
+            {buildPhases.map((phase, index) => {
+              const { date, title, description, status } = phase
+              const isLast = index === buildPhases.length - 1
+
+              return (
+                <div
+                  key={title}
+                  className="sm:basis-1/2 lg:basis-1/3 last:grow"
+                >
+                  <Phase
+                    date={date}
+                    title={title}
+                    description={description}
+                    status={status}
+                    isLast={isLast}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </SectionContent>
       </PageSection>
 
       <PageSection backgroundVariant="dark">

--- a/src/components/Phase.tsx
+++ b/src/components/Phase.tsx
@@ -1,0 +1,53 @@
+import { clsx } from 'clsx'
+
+export type PhaseProps = {
+  date: string
+  title: string
+  description: string
+  status: 'completed' | 'current' | 'upcoming'
+  isLast?: boolean
+}
+
+export function Phase({
+  date,
+  title,
+  description,
+  status,
+  isLast,
+}: PhaseProps) {
+  return (
+    <div className="flex gap-6 sm:block">
+      <div className="flex flex-col sm:flex-row items-center">
+        {/* Circle */}
+        <div
+          className={clsx(
+            'size-7 shrink-0 rounded-full border-2',
+            status === 'upcoming' ? 'border-zinc-400' : 'border-brand-600',
+          )}
+          aria-hidden="true"
+        />
+
+        {/* Line */}
+        <div
+          className={clsx(
+            'w-0.5 sm:h-0.5 flex-1',
+            status === 'completed' ? 'bg-brand-600' : 'bg-zinc-400',
+            status === 'upcoming' &&
+              isLast &&
+              'bg-linear-to-b sm:bg-linear-to-r from-zinc-400 from-30% to-zinc-50',
+          )}
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Content */}
+      <div className="mb-8 sm:mt-6 space-y-2 sm:mr-15 max-w-60">
+        <time className="text-zinc-600 text-sm inline-block" dateTime={date}>
+          {date}
+        </time>
+        <h3 className="text-xl font-medium text-zinc-950">{title}</h3>
+        <p className="text-zinc-600 text-base">{description}</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 📝 Description

This PR adds the `Phase` component and phases data for project timeline display

[UXIT-3542](https://www.notion.so/filecoin/Filecoin-Onchain-Cloud-Build-With-Us-Landing-Page-29a7631f2825805eb23ecac86d76bd44?source=copy_link)

## 📸 Screenshots

<img width="1516" height="670" alt="CleanShot 2025-10-30 at 13 04 35" src="https://github.com/user-attachments/assets/f8510aee-cae0-40ea-9eed-146caed7af86" />