### PR TITLE
Consolidate FAQ type definition in Faq component

### DIFF
--- a/src/app/hidden/(homepage)/data/faqs.tsx
+++ b/src/app/hidden/(homepage)/data/faqs.tsx
@@ -1,13 +1,8 @@
-import React, { type ReactNode } from 'react'
+import type { Question } from '@/components/Faq'
 
 import { FOC_URLS } from '@/constants/site-metadata'
 
-export type FAQ = {
-  question: string
-  answer: string | ReactNode
-}
-
-export const faqs: Array<FAQ> = [
+export const faqs: Array<Question> = [
   {
     question: 'How do I build, test, and deploy?',
     answer: (

--- a/src/components/Faq.tsx
+++ b/src/components/Faq.tsx
@@ -2,8 +2,13 @@ import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
 
 import { Accordion } from './Accordion'
 
+export type Question = {
+  question: string
+  answer: React.ReactNode
+}
+
 type FaqProps = {
-  questions: Array<{ question: string; answer: string }>
+  questions: Array<Question>
 }
 
 export function Faq({ questions }: FaqProps) {


### PR DESCRIPTION
## 📝 Description

This PR centralizes the FAQ type definition by moving the `Question` type from the data file (`faqs.tsx`) to the component file (`Faq.tsx`). This improves maintainability by keeping type definitions alongside the components that use them, following a more conventional React pattern.

- **Type:** Refactor

## 🛠️ Key Changes

- Move `Question` type definition from `src/app/hidden/(homepage)/data/faqs.tsx` to `src/components/Faq.tsx`
- Update `faqs.tsx` to import and use the centralized `Question` type
- Update `FaqProps` to use the centralized `Question` type
- Remove redundant local type definition and unused imports in `faqs.tsx`

