### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report a bug or issue with the application
+title: ""
+labels: bug
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- Browser: [e.g. Chrome, Safari]
+- Device: [e.g. Desktop, Mobile]
+- OS: [e.g. Windows, macOS, iOS]
+- API/Backend: [if applicable, e.g. API version, deployment environment]
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: ""
+labels: enhancement
+---
+
+## Feature Description
+
+A clear and concise description of the feature you'd like to see.
+
+## Problem It Solves
+
+Explain the problem this feature would solve or the use case it addresses.
+
+## Proposed Solution
+
+Describe how you envision this feature working.
+
+## Alternatives Considered
+
+Have you considered any alternative solutions or features?
+
+## Additional Context
+
+Add any other context, mockups, or examples about the feature request here.


### PR DESCRIPTION
## 📝 Description

This PR adds GitHub issue templates to streamline bug reporting and feature requests. The templates provide a consistent structure for contributors to submit issues, ensuring all necessary information is captured.

- **Type:** New feature

## 🛠️ Key Changes

- Added bug report template with sections for description, reproduction steps, expected/actual behavior, environment details (browser, device, OS, API/backend), and screenshots
- Added feature request template with sections for feature description, problem it solves, proposed solution, alternatives, and additional context
- Added `config.yml` to disable blank issues, encouraging use of templates
- Removed title prefixes (`[BUG]`, `[FEATURE]`) to avoid redundancy with labels
- Removed assignees field from templates

## 📌 To-Do Before Merging

- [x] Review template structure and fields
- [x] Confirm blank issues should be disabled

## 🧪 How to Test

- **Setup:** N/A
- **Steps to Test:**
  1. Navigate to the Issues tab after this PR is merged
  2. Click "New Issue"
  3. Verify that the bug report and feature request templates appear as options
  4. Verify that blank issues are not available
  5. Select each template and verify all fields are present and correctly formatted
- **Expected Results:** Issue templates load correctly with all defined sections
- **Additional Notes:** Templates will only be visible after merging to main

## 📸 Screenshots
<img width="2498" height="1538" alt="CleanShot 2025-11-14 at 09 02 39@2x" src="https://github.com/user-attachments/assets/45743124-5607-46af-8b49-77b1c7530928" />

## 🔖 Resources

- [GitHub Issue Templates Documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)
