### PR TITLE
[UI-Filecoin][UXIT-3661] Pass JSX to PageHeader

### DIFF
--- a/src/app/hidden/warm-storage-service/page.tsx
+++ b/src/app/hidden/warm-storage-service/page.tsx
@@ -19,7 +19,7 @@ import { Navigation } from '@/components/Navigation/Navigation'
 import { RefreshButton } from '@/components/RefreshButton'
 
 import { PATHS } from '@/constants/paths'
-import { FOC_URLS } from '@/constants/site-metadata'
+import { FIL_BEAM_URL, FOC_URLS } from '@/constants/site-metadata'
 import { truncateAddress } from '@/utils/truncate-address'
 
 import { PricingCard } from './components/PricingCard'
@@ -50,11 +50,11 @@ export default function WarmStorageService() {
           description={
             <>
               Verifiable storage powered by{' '}
-              <ExternalTextLink href={FOC_URLS.warmStorageService.pdp}>
+              <ExternalTextLink href={FOC_URLS.proofOfDataPossession}>
                 Filecoin PDP
               </ExternalTextLink>
               , with optional fast content delivery through{' '}
-              <ExternalTextLink href={FOC_URLS.warmStorageService.beam}>
+              <ExternalTextLink href={FIL_BEAM_URL}>
                 Filecoin Beam
               </ExternalTextLink>
               , a CDN gateway add-on.

--- a/src/constants/site-metadata.ts
+++ b/src/constants/site-metadata.ts
@@ -21,10 +21,8 @@ const FOC_URLS = {
     slack: 'https://filecoinproject.slack.com/archives/C07CGTXHHT4',
   },
   warmStorageService: {
-    beam: 'https://filbeam.com/',
     contactSourceCode:
       'https://github.com/FilOzone/filecoin-services/tree/main/service_contracts/src',
-    pdp: 'https://github.com/FilOzone/pdp',
     sourceCode:
       'https://github.com/FilOzone/filecoin-services/blob/main/service_contracts/src/FilecoinWarmStorageService.sol',
     spDocumentation: 'https://docs.filecoin.io/storage-providers/pdp/',


### PR DESCRIPTION
## 📝 Description

Enhance Warm Storage Service description with external links to Filecoin PDP and Beam. Update site metadata to include new URLs for Beam and PDP.

[UXIT-3661
](https://www.notion.so/filecoin/UI-Filecoin-Filecoin-Onchain-Cloud-Be-able-to-pass-JSX-to-card-descriptions-and-PageHeader-2aa7631f282580f7a7eceacddee5bc65?source=copy_link)
## 📸 Screenshots

<img width="654" height="602" alt="Screenshot 2025-11-14 at 15 33 53" src="https://github.com/user-attachments/assets/3e9416e6-8f22-4ce6-a2a5-c90b4a6617d4" />
