### PR TITLE
Truncate Peer ID

### DIFF
--- a/src/app/service-providers/data/column-definition.tsx
+++ b/src/app/service-providers/data/column-definition.tsx
@@ -1,9 +1,9 @@
 import { ID } from '@filecoin-foundation/ui-filecoin/Table/ID'
-import { CompactPeerID } from '@/components/CompactPeerID'
 import { YesNoStatus } from '@filecoin-foundation/ui-filecoin/Table/YesNoStatus'
 // import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
 import { createColumnHelper } from '@tanstack/react-table'
 
+import { CompactPeerID } from '@/components/CompactPeerID'
 import { ProviderOverview } from '@/components/ProviderOverview'
 import { SoftwareVersion } from '@/components/SoftwareVersion'
 
@@ -109,7 +109,12 @@ export const columns = [
   columnHelper.accessor('peerId', {
     header: 'Peer ID',
     maxSize: 260,
-    cell: (info) => <CompactPeerID peerId={info.getValue()} />,
+    cell: (info) => {
+      const peerId = info.getValue()
+      if (!peerId) return <span>-</span>
+      return <CompactPeerID peerId={peerId} />
+    },
     sortingFn: 'alphanumeric',
+    sortUndefined: 'last',
   }),
 ]

--- a/src/app/warm-storage-service/data/column-definition.tsx
+++ b/src/app/warm-storage-service/data/column-definition.tsx
@@ -64,7 +64,11 @@ export const columns = [
   columnHelper.accessor('peerId', {
     id: 'peerId',
     header: 'Peer ID',
-    cell: (info) => <CompactPeerID peerId={info.getValue()} />,
+    cell: (info) => {
+      const peerId = info.getValue()
+      if (!peerId) return <span>-</span>
+      return <CompactPeerID peerId={peerId} />
+    },
     sortingFn: 'alphanumeric',
     sortUndefined: 'last',
   }),

--- a/src/components/CompactPeerID.tsx
+++ b/src/components/CompactPeerID.tsx
@@ -1,51 +1,44 @@
 'use client'
 
-import { CopySimple, Check } from '@phosphor-icons/react/dist/ssr'
-import { useMemo } from 'react'
+import { Icon } from '@filecoin-foundation/ui-filecoin/Icon'
+import { Button } from '@headlessui/react'
+import { CheckSquareIcon, CopyIcon } from '@phosphor-icons/react'
 
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 import { truncatePeerID } from '@/utils/truncate-peer-id'
 
 type CompactPeerIDProps = {
-  peerId?: string | null
-  className?: string
+  peerId: string
 }
 
-export function CompactPeerID({ peerId, className }: CompactPeerIDProps) {
+export function CompactPeerID({ peerId }: CompactPeerIDProps) {
   const { copy, isCopied } = useCopyToClipboard()
 
-  const truncated = useMemo(() => truncatePeerID(peerId ?? ''), [peerId])
-
-  if (!peerId) {
-    return <span className={className ?? 'text-sm'}>-</span>
-  }
-
   return (
-    <div className={(className ?? 'inline-flex items-center min-w-0') + ' group relative'}>
-      <span
-        tabIndex={0}
-        className="font-mono text-sm truncate block max-w-[220px] whitespace-nowrap overflow-hidden"
-      >
-        {truncated}
-      </span>
-
+    <div className="inline-flex items-center gap-1">
       <div
-        className="absolute -top-8 z-50 hidden group-hover:block group-focus-within:block pointer-events-none"
-        style={{ left: '50%', transform: 'translateX(-80%)' }}
+        className="font-mono text-sm truncate whitespace-nowrap"
+        title={peerId}
       >
-        <div className="max-w-[200px] bg-slate-900 text-white text-xs rounded py-1 px-2 whitespace-normal break-words pointer-events-auto">
-          {peerId}
-        </div>
+        {truncatePeerID(peerId)}
       </div>
 
-      <button
-        type="button"
+      <Button
         onClick={() => copy(peerId)}
-        aria-label="Copy peer id"
-        className="ml-2 inline-flex items-center p-1 rounded hover:bg-slate-100 flex-shrink-0"
+        aria-label={`Copy ${peerId} to clipboard`}
+        className="grid place-items-center p-1.5 rounded-md hover:bg-zinc-200 cursor-pointer"
+        disabled={isCopied}
       >
-        {isCopied ? <Check size={16} /> : <CopySimple size={16} />}
-      </button>
+        {isCopied ? (
+          <span className="text-green-600">
+            <Icon component={CheckSquareIcon} size={18} />
+          </span>
+        ) : (
+          <span className="text-zinc-700">
+            <Icon component={CopyIcon} size={18} />
+          </span>
+        )}
+      </Button>
     </div>
   )
 }

--- a/src/utils/truncate-peer-id.ts
+++ b/src/utils/truncate-peer-id.ts
@@ -1,11 +1,15 @@
-export function truncatePeerID(
-  peerId: string | undefined | null,
-  startLength = 8,
-  endLength = 4,
-) {
-  if (!peerId) return ''
-  const asString = String(peerId)
-  // if it's already short enough, return as-is
-  if (asString.length <= startLength + endLength + 3) return asString
-  return `${asString.slice(0, startLength)}...${asString.slice(-endLength)}`
+const ELLIPSIS = '...'
+
+export function truncatePeerID(peerId: string, startLength = 8, endLength = 4) {
+  const trimmedPeerId = peerId.trim()
+
+  if (trimmedPeerId.length <= startLength + endLength + ELLIPSIS.length) {
+    return trimmedPeerId
+  }
+
+  return `
+    ${trimmedPeerId.slice(0, startLength)}
+    ${ELLIPSIS}
+    ${trimmedPeerId.slice(-endLength)}
+  `
 }


### PR DESCRIPTION
Resolves #135 
# 📝 Description

This pull request introduces a new **`CompactPeerID`** component to improve how Peer IDs are displayed and interacted with across the application.

**Problem Solved:**
Long Peer IDs cluttered table layouts, were difficult to read, and required multiple steps to copy. The new component resolves these issues by providing a cleaner UI and faster interaction.

**Type:** New feature / UI enhancement / Refactor

---

# 🛠️ Key Changes

* Introduced the new `CompactPeerID` component with:

  * Truncated display for long Peer IDs
  * Full Peer ID shown on hover/focus
  * One-click copy-to-clipboard support
  * (`src/components/CompactPeerID.tsx`)
* Added `truncatePeerID` utility for consistent truncation logic

  * (`src/utils/truncate-peer-id.ts`)
* Updated **Service Providers table** to replace `PeerID` with `CompactPeerID` and applied max column sizing

  * (`src/app/service-providers/data/column-definition.tsx`)
* Updated **Warm Storage Service table** to use `CompactPeerID`

  * (`src/app/warm-storage-service/data/column-definition.tsx`)

---

# 📌 To-Do Before Merging

* [ ] Confirm accessibility (hover, focus, screen reader text)
* [ ] Validate that copy-to-clipboard works across all supported browsers
* [ ] Add unit tests for `truncatePeerID`
* [ ] Add Storybook / UI docs for `CompactPeerID` (optional)

---

# 🧪 How to Test

### **Setup**

* Pull the branch locally
* Run the dev server:

  ```bash
  npm run dev
  ```

### **Steps to Test**

1. Navigate to **Service Providers** table
2. Confirm Peer IDs appear truncated
3. Hover or focus on the Peer ID to view full value
4. Click the copy button/icon
5. Verify the correct full Peer ID is copied to clipboard
6. Navigate to **Warm Storage Service** table
7. Repeat the same validation steps there

### **Expected Results**

* Peer IDs should display in truncated form (e.g., `12D3K...8H9Q`)
* Tooltip or hover should show full Peer ID
* Clicking the copy icon should copy the full Peer ID
* Table layout should be cleaner and more compact

### **Additional Notes**

* Ensure no regressions in sorting, filtering, or row alignment
* Confirm that mobile responsiveness is not affected

---

# 📸 Screenshots
<img width="1470" height="956" alt="Screenshot 2025-11-29 at 5 01 29 AM" src="https://github.com/user-attachments/assets/0df452bd-ee66-4219-b1e2-e16733e86148" />



