### PR TITLE
Remove filbeam bot

### DIFF
--- a/src/app/(homepage)/data/faqs.tsx
+++ b/src/app/(homepage)/data/faqs.tsx
@@ -104,14 +104,11 @@ export const faqs: Array<Question> = [
           </li>
           <li>
             <strong>Transparent rankings:</strong>{' '}
+            The{' '}
             <MarkdownLink href="https://dealbot-ga.fwss.io/">
               Storage
             </MarkdownLink>{' '}
-            and{' '}
-            <MarkdownLink href="https://github.com/filbeam/bot">
-              retrieval
-            </MarkdownLink>{' '}
-            deal checkers continuously test retrievals across the network,
+            deal checker continuously tests retrievals across the network,
             executing real deals with providers to track latency, success rates,
             and throughput.{' '}
             <MarkdownLink href="https://dashboard.filbeam.com/">


### PR DESCRIPTION
FilBeam isn't using synthetic traffic any more, only exposing real traffic metrics in dashboards.
