### PR TITLE
Update roadmap: Remove S3-compatible Object Storage API phase

### DIFF
--- a/src/app/(homepage)/data/build-phases.ts
+++ b/src/app/(homepage)/data/build-phases.ts
@@ -38,11 +38,4 @@ export const buildPhases: Array<
       'New payment and swapping end points will allow builders to pay in their native token and use Filecoin onchain verifiable storage.',
     status: 'upcoming',
   },
-  {
-    date: 'Upcoming',
-    title: 'Expose an S3-compatible Object Storage API',
-    description:
-      'Migrate from centralized S3 services to reduce trust dependencies on hyperscalers and enable user ownership of their data.',
-    status: 'upcoming',
-  },
 ]


### PR DESCRIPTION
## 📝 Description

This PR updates the roadmap by removing the 'Expose an S3-compatible Object Storage API' build phase from the upcoming features list.

- **Type:** Documentation

## 🛠️ Key Changes

- Removed the upcoming build phase for S3-compatible Object Storage API from the roadmap
- Updated `src/app/(homepage)/data/build-phases.ts` to reflect current project priorities
