### PR TITLE
Remove Filbeam retrieval bot reference from FAQs

### DIFF
--- a/src/app/(homepage)/data/faqs.tsx
+++ b/src/app/(homepage)/data/faqs.tsx
@@ -103,8 +103,7 @@ export const faqs: Array<Question> = [
             retrievals and verified egress.
           </li>
           <li>
-            <strong>Transparent rankings:</strong>{' '}
-            The{' '}
+            <strong>Transparent rankings:</strong> The{' '}
             <MarkdownLink href="https://dealbot-ga.fwss.io/">
               Storage
             </MarkdownLink>{' '}


### PR DESCRIPTION
## 📝 Description

This PR removes the reference to the Filbeam retrieval bot from the FAQs section, as the bot is no longer operational. The change simplifies the text to reference only the storage deal checker.

This replaces PR #168 originally opened by @juliangruber.

- **Type:** Bug fix / Documentation

## 🛠️ Key Changes

- Removed the "and retrieval" text and Filbeam bot link from the transparent rankings FAQ
- Simplified the sentence to only reference the storage deal checker
- Updated text from "deal checkers" (plural) to "deal checker" (singular)

## 📌 To-Do Before Merging

- [x] Review the updated FAQ text for clarity

## 🧪 How to Test

- **Setup:** No setup required
- **Steps to Test:**
  1. Navigate to the homepage FAQs section
  2. Find the "Transparent rankings" bullet point
  3. Verify the Filbeam retrieval bot link has been removed
  4. Verify the text reads naturally with only the storage deal checker referenced
- **Expected Results:** FAQ text should be accurate and reflect current tooling
- **Additional Notes:** This is a content-only change

## 🔖 Resources

- Original PR: https://github.com/FilOzone/filecoin-cloud/pull/168