### PR TITLE
Fix broken dealbot link in FAQs

### DIFF
--- a/src/app/(homepage)/data/faqs.tsx
+++ b/src/app/(homepage)/data/faqs.tsx
@@ -104,9 +104,7 @@ export const faqs: Array<Question> = [
           </li>
           <li>
             <strong>Transparent rankings:</strong> The{' '}
-            <MarkdownLink href="https://dealbot-ga.fwss.io/">
-              Storage
-            </MarkdownLink>{' '}
+            <MarkdownLink href="https://dealbot.fwss.io/">Storage</MarkdownLink>{' '}
             deal checker continuously tests retrievals across the network,
             executing real deals with providers to track latency, success rates,
             and throughput.{' '}


### PR DESCRIPTION
## 📝 Description

Fixes broken dealbot link in the FAQ section. The Storage deal checker link was pointing to a non-existent URL (https://dealbot-ga.fwss.io/) and has been updated to the correct URL (https://dealbot.fwss.io/).

- **Type:** Bug fix

Fixes #182

## 🛠️ Key Changes

- Updated Storage link URL from `https://dealbot-ga.fwss.io/` to `https://dealbot.fwss.io/` in the "Transparent rankings" section of the "What are the performance guarantees?" FAQ

## 📌 To-Do Before Merging

- [x] Verify the new URL is accessible and correct

## 🧪 How to Test

- **Setup:** Run the development server
- **Steps to Test:**
  1. Navigate to the homepage FAQs section
  2. Find the "What are the performance guarantees?" question
  3. Locate the "Transparent rankings" bullet point
  4. Click the "Storage" link
  5. Verify it navigates to the correct dealbot page
- **Expected Results:** Link opens the dealbot page at https://dealbot.fwss.io/
- **Additional Notes:** None

## 📸 Screenshots

N/A - Link fix only

## 🔖 Resources

- Closes Issue #182
- Slack thread: https://filecoinproject.slack.com/archives/C08TVNKJV7C/p1766137460656019