### PR TITLE
[UXIT-3837] Fix Service Provider table z index issue

### DIFF
--- a/src/app/service-providers/components/DesktopTableFilters.tsx
+++ b/src/app/service-providers/components/DesktopTableFilters.tsx
@@ -4,12 +4,7 @@ import {
   backgroundVariants,
   useBackground,
 } from '@filecoin-foundation/ui-filecoin/Section/Section'
-import {
-  Popover,
-  PopoverBackdrop,
-  PopoverButton,
-  PopoverPanel,
-} from '@headlessui/react'
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
 import { FunnelSimpleIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
@@ -50,13 +45,11 @@ export function DesktopTableFilters({ options }: DesktopTableFiltersProps) {
             </span>
           </PopoverButton>
 
-          <PopoverBackdrop className="fixed inset-0 bg-zinc-950/5" />
-
           <PopoverPanel
             anchor={{ to: 'bottom', gap: 16 }}
             className={clsx(
               backgroundVariants[theme],
-              '@container w-[640px] max-h-[80vh] overflow-y-auto p-6 rounded-2xl border border-(--color-listbox-border) shadow-xs',
+              '@container w-[640px] z-20 max-h-[80vh] overflow-y-auto p-6 rounded-2xl border border-(--color-listbox-border) shadow-xl',
             )}
           >
             <div className="flex gap-16">

--- a/src/app/warm-storage-service/components/LocationFilter.tsx
+++ b/src/app/warm-storage-service/components/LocationFilter.tsx
@@ -9,7 +9,6 @@ import {
 import {
   Fieldset,
   Popover,
-  PopoverBackdrop,
   PopoverButton,
   PopoverPanel,
 } from '@headlessui/react'
@@ -52,13 +51,11 @@ export function LocationFilter({ options }: LocationFilterProps) {
             </span>
           </PopoverButton>
 
-          <PopoverBackdrop className="fixed inset-0 bg-zinc-950/5" />
-
           <PopoverPanel
             anchor={{ to: 'bottom', gap: 16 }}
             className={clsx(
               backgroundVariants[theme],
-              'w-80 max-h-96 overflow-y-auto p-6 rounded-2xl border border-(--color-listbox-border) shadow-xs',
+              'w-80 max-h-96 overflow-y-auto p-6 rounded-2xl border border-(--color-listbox-border) shadow-xl z-20',
             )}
           >
             <Fieldset>


### PR DESCRIPTION
## 📝 Description

### Issue
Popover components were experiencing z-index layering issues and inconsistent styling, affecting the visual hierarchy and user experience.

https://github.com/user-attachments/assets/6d37d2f1-c72f-46c8-9d20-c892fdbb5ea5


### Changes
- Removed `PopoverBackdrop` component from `DesktopTableFilters` and `LocationFilter` components as it was causing visual issues - instead enhanced shadow styling from `shadow-xs` to `shadow-xl` for better visual depth and consistency - to double check with Filipa if this works from the design perspective
- Added explicit `z-20`` z-index` to `PopoverPanel` elements to ensure proper stacking context

❗️NetworkSelector component still has a stacking issue - needs to be resolved in the `filecoin-ui` library

## 📸 Screenshots

<img width="878" height="853" alt="Screenshot 2026-01-09 at 10 36 35" src="https://github.com/user-attachments/assets/78c6f2b8-8a0a-49c3-a294-ebabe7923694" />
<img width="878" height="853" alt="Screenshot 2026-01-09 at 10 41 07" src="https://github.com/user-attachments/assets/82d4e5d8-53c2-442b-8346-227e2a04c72d" />

