### PR TITLE
Add Resources dropdown navigation with nested menu support

### DIFF
--- a/src/components/Navigation/DesktopNavigation.tsx
+++ b/src/components/Navigation/DesktopNavigation.tsx
@@ -3,16 +3,23 @@
 import { NavigationMainLink } from '@filecoin-foundation/ui-filecoin/Navigation/NavigationMainLink'
 
 import { headerNavigationItems } from './constants/navigation'
+import { NavigationMenu } from './NavigationMenu'
 
 export function DesktopNavigation() {
   return (
     <div className="flex w-full items-center justify-end gap-4">
       <ul aria-label="Main navigation menu" className="flex items-center gap-6">
-        {headerNavigationItems.map((item) => (
-          <li key={item.href}>
-            <NavigationMainLink on="desktop" {...item} />
-          </li>
-        ))}
+        {headerNavigationItems.map((item) => {
+          if ('items' in item) {
+            return <NavigationMenu key={item.label} {...item} />
+          }
+
+          return (
+            <li key={item.href}>
+              <NavigationMainLink on="desktop" {...item} />
+            </li>
+          )
+        })}
       </ul>
     </div>
   )

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -5,7 +5,7 @@ import {
   type SectionProps,
 } from '@filecoin-foundation/ui-filecoin/Section/Section'
 
-import { headerNavigationItems } from './constants/navigation'
+import { mobileNavigationItems } from './constants/navigation'
 import { DesktopNavigation } from './DesktopNavigation'
 import { HomeLogoIconLink } from './HomeLogoIconLink'
 
@@ -22,7 +22,7 @@ export function Navigation({ backgroundVariant }: NavigationProps) {
 
           <div className="block lg:hidden">
             <MobileNavigation
-              items={headerNavigationItems}
+              items={mobileNavigationItems}
               HomeLogoIconLinkComponent={HomeLogoIconLink}
             />
           </div>

--- a/src/components/Navigation/NavigationMenu.tsx
+++ b/src/components/Navigation/NavigationMenu.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useIsNavigationMenuActive } from '@filecoin-foundation/ui-filecoin/Navigation/hooks/useIsNavigationMenuActive'
+import { NavigationMenu as SharedNavigationMenu } from '@filecoin-foundation/ui-filecoin/Navigation/NavigationMenu'
+import { NavigationMenuPanel } from '@filecoin-foundation/ui-filecoin/Navigation/NavigationMenuPanel'
+import type { NavigationMenuItem } from '@filecoin-foundation/ui-filecoin/Navigation/types'
+
+export function NavigationMenu({ label, items }: NavigationMenuItem) {
+  const isActive = useIsNavigationMenuActive(items)
+
+  return (
+    <SharedNavigationMenu as="li" label={label} isCurrent={isActive}>
+      <NavigationMenuPanel items={items} />
+    </SharedNavigationMenu>
+  )
+}

--- a/src/components/Navigation/constants/navigation.ts
+++ b/src/components/Navigation/constants/navigation.ts
@@ -1,9 +1,46 @@
-import type { NavItem } from '@filecoin-foundation/ui-filecoin/Navigation/types'
+import type {
+  NavItem,
+  NavigationMenuItem,
+} from '@filecoin-foundation/ui-filecoin/Navigation/types'
 
 import { PATHS } from '@/constants/paths'
 import { FOC_URLS } from '@/constants/site-metadata'
 
-export const headerNavigationItems: Array<NavItem> = [
+export const headerNavigationItems: Array<NavItem | NavigationMenuItem> = [
+  {
+    label: PATHS.WARM_STORAGE_SERVICE.label,
+    href: PATHS.WARM_STORAGE_SERVICE.path,
+  },
+  {
+    label: PATHS.SERVICE_PROVIDERS.label,
+    href: PATHS.SERVICE_PROVIDERS.path,
+  },
+  {
+    label: 'Resources',
+    items: [
+      {
+        title: 'Resources',
+        links: [
+          {
+            description: 'Learn about the Filecoin Agents program',
+            label: PATHS.AGENTS.label,
+            href: PATHS.AGENTS.path,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Filecoin Pay',
+    href: FOC_URLS.filecoinPay,
+  },
+  {
+    label: 'Documentation',
+    href: FOC_URLS.documentation.home,
+  },
+]
+
+export const mobileNavigationItems: Array<NavItem> = [
   {
     label: PATHS.WARM_STORAGE_SERVICE.label,
     href: PATHS.WARM_STORAGE_SERVICE.path,


### PR DESCRIPTION
## 📝 Description

This PR enhances the navigation component to support dropdown menus with nested items, and adds a new "Resources" navigation section.

- **Type:** New feature

## 🛠️ Key Changes

- Add new `NavigationMenu` component for rendering dropdown menus with nested items
- Update `DesktopNavigation` to conditionally render dropdown menus when items have nested children
- Add "Resources" dropdown with links to Filecoin Allocator, Built with Filecoin, and Case Studies
- Add "Filecoin Pay" and "Documentation" navigation items
- Create separate `mobileNavigationItems` array for mobile-specific navigation structure

Fixes #230 