### PR TITLE
Create dynamic sitemap with static and agent routes

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,25 +1,26 @@
-import type { MetadataRoute } from "next";
-import { getAllRFSData } from "@/app/agents/utils/get-rfs-data";
-import { PATHS } from "@/constants/paths";
-import { BASE_URL } from "@/constants/site-metadata";
+import type { MetadataRoute } from 'next'
+
+import { getAllRFSData } from '@/app/agents/utils/get-rfs-data'
+import { PATHS } from '@/constants/paths'
+import { BASE_URL } from '@/constants/site-metadata'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const lastModified = new Date();
+  const lastModified = new Date()
 
   const staticRoutes = Object.values(PATHS).map(({ path }) => ({
     url: `${BASE_URL}${path}`,
     lastModified,
-    changeFrequency: "weekly" as const,
-    priority: path === "/" ? 1 : 0.8,
-  }));
+    changeFrequency: 'weekly' as const,
+    priority: path === '/' ? 1 : 0.8,
+  }))
 
-  const allRFSData = await getAllRFSData();
+  const allRFSData = await getAllRFSData()
   const agentRoutes = allRFSData.map(({ slug }) => ({
     url: `${BASE_URL}${PATHS.AGENTS.path}/${slug}`,
     lastModified,
-    changeFrequency: "weekly" as const,
+    changeFrequency: 'weekly' as const,
     priority: 0.7,
-  }));
+  }))
 
-  return [...staticRoutes, ...agentRoutes];
+  return [...staticRoutes, ...agentRoutes]
 }


### PR DESCRIPTION
## 📝 Description

This PR implements a dynamic sitemap that includes both static routes and dynamically generated agent routes. This improves SEO by ensuring all pages are discoverable by search engines.

- **Type:** New feature

NOTE: Will add a `lastUpdated` field to the `/agents[slug]` pages in a separate PR.

Fixes: #248 

## 🛠️ Key Changes

- Converted sitemap from static to async function to fetch agent data
- Added static routes from PATHS constants with appropriate priority levels
- Added dynamic agent routes by fetching all RFS data and generating URLs for each agent
- Set home page priority to 1, static pages to 0.8, and agent pages to 0.7
- Updated Badge component to disable text transformation for proper styling
- Bumped @filecoin-foundation/ui-filecoin dependency to 0.8.0

## 📌 To-Do Before Merging

- [x] Verify sitemap generates correctly at /sitemap.xml
- [x] Check that all expected routes appear in the sitemap
- [x] Confirm sitemap format is valid for search engines

## 🧪 How to Test

- **Setup:** Run the development server
- **Steps to Test:**
  1. Navigate to http://localhost:3000/sitemap.xml
  2. Verify all static routes (home, agents, etc.) are present
  3. Verify all agent routes are listed with correct slugs
  4. Check that priorities are set correctly (home=1, static=0.8, agents=0.7)
- **Expected Results:** A valid XML sitemap displaying all routes with appropriate metadata
- **Additional Notes:** The sitemap will update automatically as new agents are added

## 📸 Screenshots

<img width="1032" height="2510" alt="CleanShot 2026-02-18 at 08 54 34@2x" src="https://github.com/user-attachments/assets/7f500cc8-f565-4f66-9aaa-a24bf2747dfa" />


## 🔖 Resources

- [Next.js Sitemap Documentation](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
