### PR TITLE
fix: add SEO metadata and JSON-LD for agents pages

### DIFF
--- a/src/app/agents/[slug]/page.tsx
+++ b/src/app/agents/[slug]/page.tsx
@@ -6,11 +6,16 @@ import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
 import { notFound } from 'next/navigation'
 
 import { Navigation } from '@/components/Navigation/Navigation'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
+import { PATHS } from '@/constants/paths'
 import { FOC_URLS } from '@/constants/site-metadata'
+import { createMetadata } from '@/utils/create-metadata'
 import { getMarkdownSlugs } from '@/utils/markdown'
 
 import { SubmitProposalButton } from '../components/SubmitProposalButton'
+import { getRFSSeo } from '../constants/seo'
+import { generateRFSStructuredData } from '../utils/generate-structured-data'
 import { getRFSData, OPEN_REQUESTS_DIR } from '../utils/get-rfs-data'
 
 type RFSPageProps = {
@@ -25,6 +30,13 @@ export default async function RFSPage({ params }: RFSPageProps) {
 
     return (
       <>
+        <StructuredDataScript
+          structuredData={generateRFSStructuredData({
+            ...rfsData.data,
+            slug,
+          })}
+        />
+
         <Navigation backgroundVariant="light" />
         <PageSection backgroundVariant="light" paddingVariant="topCompact">
           <article className="flex items-start flex-col space-y-10">
@@ -116,11 +128,13 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: RFSPageProps) {
   const { slug } = await params
   const rfsData = await getRFSData(slug)
+  const seo = getRFSSeo(rfsData.data)
 
-  return {
-    title: rfsData.data.title,
-    description: rfsData.data.description,
-  }
+  return createMetadata({
+    title: seo.title,
+    description: seo.description,
+    path: `${PATHS.AGENTS.path}/${slug}`,
+  })
 }
 
 export const dynamicParams = false

--- a/src/app/agents/constants/seo.ts
+++ b/src/app/agents/constants/seo.ts
@@ -1,5 +1,41 @@
 export const AGENTS_SEO = {
-  title: 'Agents: Requests for Startups',
+  title: 'AI Agent Startup Requests | Filecoin Onchain Cloud',
   description:
-    'Explore startup opportunities and requests for proposals in the Filecoin ecosystem. Discover areas where innovation is needed and how you can contribute.',
+    'Explore Filecoin Onchain Cloud requests for startups building AI agent infrastructure for autonomous storage, payments, identity, coordination, and markets.',
 } as const
+
+const META_DESCRIPTION_MAX_LENGTH = 160
+const ELLIPSIS = '...'
+
+type RFSSEOParams = {
+  id: string
+  title: string
+  description: string
+}
+
+export function getRFSSeo({ id, title, description }: RFSSEOParams) {
+  return {
+    title: `RFS-${id}: ${title} | Filecoin Cloud`,
+    description: createMetaDescription(description),
+  }
+}
+
+function createMetaDescription(description: string) {
+  if (description.length <= META_DESCRIPTION_MAX_LENGTH) {
+    return description
+  }
+
+  const truncated = description.slice(
+    0,
+    META_DESCRIPTION_MAX_LENGTH - ELLIPSIS.length,
+  )
+  const lastSentence = truncated.lastIndexOf('. ')
+
+  if (lastSentence > 90) {
+    return truncated.slice(0, lastSentence + 1)
+  }
+
+  const lastSpace = truncated.lastIndexOf(' ')
+
+  return `${truncated.slice(0, lastSpace)}${ELLIPSIS}`
+}

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -27,7 +27,10 @@ export default async function Agents() {
   return (
     <>
       <StructuredDataScript
-        structuredData={generateStructuredData(AGENTS_SEO)}
+        structuredData={generateStructuredData(
+          AGENTS_SEO,
+          rfsDataList.map(({ data, slug }) => ({ ...data, slug })),
+        )}
       />
 
       <Navigation backgroundVariant="dark" />

--- a/src/app/agents/utils/generate-structured-data.ts
+++ b/src/app/agents/utils/generate-structured-data.ts
@@ -1,16 +1,135 @@
+import type { Article, CollectionPage, ItemList, ListItem } from 'schema-dts'
+
 import type { WebPageGraph } from '@/components/StructuredDataScript'
 
 import { PATHS } from '@/constants/paths'
+import { BASE_URL } from '@/constants/site-metadata'
+import { ORGANIZATION_ID } from '@/constants/structured-data'
 import type { StructuredDataParams } from '@/types/structured-data-params'
 import { generatePageStructuredData } from '@/utils/generate-page-structured-data'
 
+import { AGENTS_SEO, getRFSSeo } from '../constants/seo'
+
+type RFSStructuredDataParams = StructuredDataParams & {
+  id: string
+  slug: string
+}
+
+type GraphNodeWithMainEntity = {
+  mainEntity?: { '@id': string }
+}
+
+type RFSItemList = ItemList & {
+  '@id': string
+}
+
 export function generateStructuredData(
   seo: StructuredDataParams,
+  requests: Array<RFSStructuredDataParams> = [],
 ): WebPageGraph {
-  return generatePageStructuredData({
+  const structuredData = generatePageStructuredData({
     title: seo.title,
     description: seo.description,
     path: PATHS.AGENTS.path,
-    pageType: 'WebPage',
+    pageType: 'CollectionPage',
   })
+
+  if (requests.length === 0) {
+    return structuredData
+  }
+
+  const requestItemList = generateRFSItemList(requests)
+  const collectionPage = findGraphNodeByType<
+    CollectionPage & GraphNodeWithMainEntity
+  >(structuredData, 'CollectionPage')
+
+  if (collectionPage) {
+    collectionPage.mainEntity = { '@id': requestItemList['@id'] }
+  }
+
+  structuredData['@graph'].push(requestItemList)
+
+  return structuredData
+}
+
+export function generateRFSStructuredData(
+  request: RFSStructuredDataParams,
+): WebPageGraph {
+  const seo = getRFSSeo(request)
+  const path = `${PATHS.AGENTS.path}/${request.slug}` as `/${string}`
+  const webPageUrl = `${BASE_URL}${path}`
+  const webPageId = `${webPageUrl}/#webpage`
+  const articleId = `${webPageUrl}/#article`
+  const structuredData = generatePageStructuredData({
+    title: seo.title,
+    description: seo.description,
+    path,
+    pageType: 'WebPage',
+    parentPaths: [{ path: PATHS.AGENTS.path, title: AGENTS_SEO.title }],
+  })
+
+  const webPage = findGraphNodeById<GraphNodeWithMainEntity>(
+    structuredData,
+    webPageId,
+  )
+
+  if (webPage) {
+    webPage.mainEntity = { '@id': articleId }
+  }
+
+  const article: Article = {
+    '@type': 'Article',
+    '@id': articleId,
+    headline: `RFS-${request.id}: ${request.title}`,
+    name: request.title,
+    description: request.description,
+    url: webPageUrl,
+    author: { '@id': ORGANIZATION_ID },
+    publisher: { '@id': ORGANIZATION_ID },
+    isPartOf: { '@id': webPageId },
+    mainEntityOfPage: { '@id': webPageId },
+  }
+
+  structuredData['@graph'].push(article)
+
+  return structuredData
+}
+
+function generateRFSItemList(
+  requests: Array<RFSStructuredDataParams>,
+): RFSItemList {
+  const itemListElement: ListItem[] = requests.map((request, index) => {
+    const url = `${BASE_URL}${PATHS.AGENTS.path}/${request.slug}`
+
+    return {
+      '@type': 'ListItem',
+      position: index + 1,
+      url,
+      name: `RFS-${request.id}: ${request.title}`,
+      description: request.description,
+    }
+  })
+
+  return {
+    '@type': 'ItemList',
+    '@id': `${BASE_URL}${PATHS.AGENTS.path}/#requests-for-startups`,
+    name: 'Open AI Agent Requests for Startups',
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: requests.length,
+    itemListElement,
+  }
+}
+
+function findGraphNodeByType<T>(structuredData: WebPageGraph, type: string) {
+  return structuredData['@graph'].find((node) => {
+    const nodeType = (node as { '@type'?: string | Array<string> })['@type']
+
+    return Array.isArray(nodeType) ? nodeType.includes(type) : nodeType === type
+  }) as T | undefined
+}
+
+function findGraphNodeById<T>(structuredData: WebPageGraph, id: string) {
+  return structuredData['@graph'].find(
+    (node) => (node as { '@id'?: string })['@id'] === id,
+  ) as T | undefined
 }

--- a/src/components/StructuredDataScript.tsx
+++ b/src/components/StructuredDataScript.tsx
@@ -1,5 +1,7 @@
 import type {
+  Article,
   BreadcrumbList,
+  ItemList,
   Organization,
   Service,
   Thing,
@@ -12,7 +14,15 @@ import type { SCHEMA_CONTEXT_URL } from '@/constants/structured-data'
 
 export type WebPageGraph = {
   '@context': typeof SCHEMA_CONTEXT_URL
-  '@graph': Array<WebPage | BreadcrumbList | Organization | WebSite | Service>
+  '@graph': Array<
+    | WebPage
+    | BreadcrumbList
+    | Organization
+    | WebSite
+    | Service
+    | ItemList
+    | Article
+  >
 }
 
 export type ServicePageGraph = {

--- a/src/utils/create-metadata.ts
+++ b/src/utils/create-metadata.ts
@@ -39,6 +39,7 @@ export function createMetadata({
 }: MetadataParams) {
   const imageUrl = image || DEFAULT_SOCIAL_IMAGE
   const defaultImage = [{ url: imageUrl }]
+  const pageUrl = `${BASE_URL}${path}`
 
   const {
     metadataBase,
@@ -57,7 +58,7 @@ export function createMetadata({
       title: openGraph.title || title,
       description: openGraph.description || description,
       images: openGraph.image ? [{ url: openGraph.image }] : defaultImage,
-      url: BASE_URL,
+      url: pageUrl,
     },
     twitter: {
       ...defaultTwitter,

--- a/src/utils/generate-breadcrumb-list.ts
+++ b/src/utils/generate-breadcrumb-list.ts
@@ -1,12 +1,12 @@
 import type { BreadcrumbList, ListItem } from 'schema-dts'
 
-import { type NextRoute, PATHS } from '@/constants/paths'
+import { PATHS } from '@/constants/paths'
 import { BASE_URL } from '@/constants/site-metadata'
 
 type GenerateBreadcrumbListProps = {
   path: string
   title: string
-  parentPaths?: Array<{ path: NextRoute; title: string }>
+  parentPaths?: Array<{ path: string; title: string }>
 }
 
 export function generateBreadcrumbList({

--- a/src/utils/generate-page-structured-data.ts
+++ b/src/utils/generate-page-structured-data.ts
@@ -1,6 +1,5 @@
 import type { WebPage } from 'schema-dts'
 
-import type { NextRoute } from '@/constants/paths'
 import { BASE_URL } from '@/constants/site-metadata'
 import type { StructuredDataParams } from '@/types/structured-data-params'
 
@@ -20,9 +19,10 @@ import { generateImageObject } from './generate-image-object'
 import { generateServiceSchema } from './generate-service-schema'
 
 type GenerateWebPageStructuredDataProps = StructuredDataParams & {
-  path: NextRoute
+  path: `/${string}`
   pageType: PageType
   imageUrl?: string
+  parentPaths?: Array<{ path: string; title: string }>
   service?: {
     name: string
     description: string
@@ -40,6 +40,7 @@ export function generatePageStructuredData({
   path,
   pageType,
   imageUrl,
+  parentPaths,
   service,
 }: GenerateWebPageStructuredDataProps): WebPageGraph {
   const webPageUrl = `${BASE_URL}${path}`
@@ -77,7 +78,7 @@ export function generatePageStructuredData({
     graph.push(serviceSchema)
   }
 
-  const breadcrumbList = generateBreadcrumbList({ path, title })
+  const breadcrumbList = generateBreadcrumbList({ path, title, parentPaths })
   if (breadcrumbList) {
     graph.push(breadcrumbList)
   }


### PR DESCRIPTION
## 📝 Description

Closes #245.

Adds SEO metadata and structured data coverage for the Agents pages:

- Updates `/agents` meta title and description copy
- Adds unique metadata for each `/agents/[slug]` RFS detail page
- Adds canonical and Open Graph URLs for dynamic agent pages
- Adds JSON-LD `ItemList` structured data for the Agents listing page
- Adds JSON-LD `Article` structured data for individual RFS pages
- Extends shared structured-data helpers to support dynamic child routes and breadcrumbs