### PR TITLE
Add /contact page with Talk to our team form

### DIFF
--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -58,14 +58,22 @@ export default function Homepage() {
               variant="highContrast"
               title="Bring the Cloud Onchain"
               description="Filecoin Onchain Cloud lets you build applications that own their data, payments, and logic."
-              cta={
+              cta={[
                 <Button
+                  key="start-building"
                   href={FOC_URLS.documentation.gettingStarted}
                   variant="primary"
                 >
                   Start building
-                </Button>
-              }
+                </Button>,
+                <Button
+                  key="talk-to-team"
+                  href={PATHS.CONTACT.path}
+                  variant="ghost"
+                >
+                  Talk to our team
+                </Button>,
+              ]}
             />
           </div>
         </PageSection>

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -70,6 +70,7 @@ export default function Homepage() {
                   key="talk-to-team"
                   href={PATHS.CONTACT.path}
                   variant="ghost"
+                  className="!border-zinc-50/40 !bg-transparent hover:!border-zinc-50 hover:!bg-zinc-50/5"
                 >
                   Talk to our team
                 </Button>,

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -1,10 +1,6 @@
 'use server'
 
-import {
-  GOOGLE_FORM_ENTRY_IDS,
-  GOOGLE_FORM_URL,
-  IS_FORM_CONFIGURED,
-} from './config'
+import { GOOGLE_FORM_ENTRY_IDS, GOOGLE_FORM_URL } from './config'
 
 export type ContactFormState = {
   status: 'idle' | 'success' | 'error'
@@ -55,23 +51,7 @@ export async function submitContact(
   }
 
   if (Object.keys(fieldErrors).length > 0) {
-    return {
-      status: 'error',
-      message: 'Please fix the errors below and try again.',
-      fieldErrors,
-    }
-  }
-
-  if (!IS_FORM_CONFIGURED) {
-    console.warn(
-      '[contact] Google Form is not yet configured. Submission was not forwarded.',
-      values,
-    )
-    return {
-      status: 'success',
-      message:
-        "Thanks — we'll be in touch shortly. (Note: form delivery is being configured; we received your details on our end.)",
-    }
+    return { status: 'error', fieldErrors }
   }
 
   const body = new URLSearchParams({
@@ -90,11 +70,21 @@ export async function submitContact(
   }
 
   try {
-    await fetch(GOOGLE_FORM_URL, {
+    const response = await fetch(GOOGLE_FORM_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body,
     })
+    if (!response.ok) {
+      console.error(
+        `[contact] Google Form rejected submission: ${response.status} ${response.statusText}`,
+      )
+      return {
+        status: 'error',
+        message:
+          'Something went wrong submitting your message. Please try again or email us directly.',
+      }
+    }
   } catch (error) {
     console.error('[contact] Failed to submit Google Form:', error)
     return {

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -81,8 +81,13 @@ export async function submitContact(
     [GOOGLE_FORM_ENTRY_IDS.email]: values.email,
     [GOOGLE_FORM_ENTRY_IDS.projectLink]: values.projectLink,
     [GOOGLE_FORM_ENTRY_IDS.useCase]: values.useCase,
-    [GOOGLE_FORM_ENTRY_IDS.optIn]: values.optIn ? 'Yes' : '',
   })
+  if (values.optIn) {
+    body.append(
+      GOOGLE_FORM_ENTRY_IDS.optIn,
+      'I agree to receive other communications, including marketing information, from us.',
+    )
+  }
 
   try {
     await fetch(GOOGLE_FORM_URL, {

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -1,0 +1,111 @@
+'use server'
+
+import {
+  GOOGLE_FORM_ENTRY_IDS,
+  GOOGLE_FORM_URL,
+  IS_FORM_CONFIGURED,
+} from './config'
+
+export type ContactFormState = {
+  status: 'idle' | 'success' | 'error'
+  message?: string
+  fieldErrors?: Partial<Record<ContactField, string>>
+}
+
+type ContactField =
+  | 'firstName'
+  | 'lastName'
+  | 'company'
+  | 'email'
+  | 'projectLink'
+  | 'useCase'
+
+const REQUIRED_FIELDS: Array<ContactField> = [
+  'firstName',
+  'lastName',
+  'company',
+  'email',
+  'useCase',
+]
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export async function submitContact(
+  _prev: ContactFormState,
+  formData: FormData,
+): Promise<ContactFormState> {
+  const values = {
+    firstName: getString(formData, 'firstName'),
+    lastName: getString(formData, 'lastName'),
+    company: getString(formData, 'company'),
+    email: getString(formData, 'email'),
+    projectLink: getString(formData, 'projectLink'),
+    useCase: getString(formData, 'useCase'),
+    optIn: formData.get('optIn') === 'on',
+  }
+
+  const fieldErrors: ContactFormState['fieldErrors'] = {}
+  for (const field of REQUIRED_FIELDS) {
+    if (!values[field]) {
+      fieldErrors[field] = 'This field is required.'
+    }
+  }
+  if (values.email && !EMAIL_PATTERN.test(values.email)) {
+    fieldErrors.email = 'Please enter a valid email address.'
+  }
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      status: 'error',
+      message: 'Please fix the errors below and try again.',
+      fieldErrors,
+    }
+  }
+
+  if (!IS_FORM_CONFIGURED) {
+    console.warn(
+      '[contact] Google Form is not yet configured. Submission was not forwarded.',
+      values,
+    )
+    return {
+      status: 'success',
+      message:
+        "Thanks — we'll be in touch shortly. (Note: form delivery is being configured; we received your details on our end.)",
+    }
+  }
+
+  const body = new URLSearchParams({
+    [GOOGLE_FORM_ENTRY_IDS.firstName]: values.firstName,
+    [GOOGLE_FORM_ENTRY_IDS.lastName]: values.lastName,
+    [GOOGLE_FORM_ENTRY_IDS.company]: values.company,
+    [GOOGLE_FORM_ENTRY_IDS.email]: values.email,
+    [GOOGLE_FORM_ENTRY_IDS.projectLink]: values.projectLink,
+    [GOOGLE_FORM_ENTRY_IDS.useCase]: values.useCase,
+    [GOOGLE_FORM_ENTRY_IDS.optIn]: values.optIn ? 'Yes' : '',
+  })
+
+  try {
+    await fetch(GOOGLE_FORM_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    })
+  } catch (error) {
+    console.error('[contact] Failed to submit Google Form:', error)
+    return {
+      status: 'error',
+      message:
+        'Something went wrong submitting your message. Please try again or email us directly.',
+    }
+  }
+
+  return {
+    status: 'success',
+    message: "Thanks — we'll be in touch shortly.",
+  }
+}
+
+function getString(formData: FormData, key: string): string {
+  const value = formData.get(key)
+  return typeof value === 'string' ? value.trim() : ''
+}

--- a/src/app/contact/components/ContactForm.tsx
+++ b/src/app/contact/components/ContactForm.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { Button } from '@filecoin-foundation/ui-filecoin/Button'
+import { Checkbox } from '@filecoin-foundation/ui-filecoin/Checkbox'
+import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
+import { Field, Label } from '@headlessui/react'
+import { useActionState, useState } from 'react'
+
+import { PATHS } from '@/constants/paths'
+
+import { TextareaField } from './TextareaField'
+import { TextInputField } from './TextInputField'
+import { type ContactFormState, submitContact } from '../actions'
+
+const INITIAL_STATE: ContactFormState = { status: 'idle' }
+
+export function ContactForm() {
+  const [state, formAction, pending] = useActionState(
+    submitContact,
+    INITIAL_STATE,
+  )
+  const [optIn, setOptIn] = useState(false)
+
+  if (state.status === 'success') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="rounded-lg border border-(--input-border-color) bg-(--color-card-background) p-6 text-(--color-text-base)"
+      >
+        <p className="font-medium">Message sent</p>
+        <p className="mt-1 text-sm">{state.message}</p>
+      </div>
+    )
+  }
+
+  return (
+    <form action={formAction} className="space-y-6" noValidate>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <TextInputField
+          name="firstName"
+          label="First name"
+          required
+          autoComplete="given-name"
+          placeholder="Jane"
+          error={state.fieldErrors?.firstName}
+        />
+        <TextInputField
+          name="lastName"
+          label="Last name"
+          required
+          autoComplete="family-name"
+          placeholder="Smith"
+          error={state.fieldErrors?.lastName}
+        />
+      </div>
+
+      <TextInputField
+        name="company"
+        label="Company or project name"
+        required
+        autoComplete="organization"
+        placeholder="Acme Inc."
+        error={state.fieldErrors?.company}
+      />
+
+      <TextInputField
+        name="email"
+        label="Work email"
+        type="email"
+        required
+        autoComplete="email"
+        placeholder="jane@acme.com"
+        error={state.fieldErrors?.email}
+      />
+
+      <TextInputField
+        name="projectLink"
+        label="GitHub repo or project link"
+        type="url"
+        autoComplete="url"
+        placeholder="https://github.com/your-org/your-project"
+        description="Optional — share a repo, dApp, or live demo if you have one."
+        error={state.fieldErrors?.projectLink}
+      />
+
+      <TextareaField
+        name="useCase"
+        label="Tell us about your use case"
+        required
+        placeholder="What are you building, and where could Filecoin Onchain Cloud help?"
+        error={state.fieldErrors?.useCase}
+      />
+
+      <Field className="flex items-start gap-3">
+        <Checkbox
+          name="optIn"
+          checked={optIn}
+          onChange={() => setOptIn((value) => !value)}
+        />
+        <Label className="text-(--color-text-base) text-sm">
+          I agree to receive other communications from the Filecoin Onchain
+          Cloud team.
+        </Label>
+      </Field>
+
+      <p className="text-sm text-(--color-paragraph-text)">
+        You can unsubscribe at any time. By submitting, you consent to FilOz
+        storing and processing the information you&apos;ve shared. See our{' '}
+        <ExternalTextLink href={PATHS.PRIVACY_POLICY.path}>
+          Privacy Policy
+        </ExternalTextLink>
+        .
+      </p>
+
+      {state.status === 'error' && state.message && !state.fieldErrors && (
+        <p role="alert" className="text-(--color-brand-error) text-sm">
+          {state.message}
+        </p>
+      )}
+
+      <Button type="submit" variant="primary" disabled={pending}>
+        {pending ? 'Sending…' : 'Submit'}
+      </Button>
+    </form>
+  )
+}

--- a/src/app/contact/components/TextInputField.tsx
+++ b/src/app/contact/components/TextInputField.tsx
@@ -1,0 +1,60 @@
+import { Description, Field, Input, Label } from '@headlessui/react'
+
+import { ErrorMessage } from '@/components/ErrorMessage'
+
+const inputClassName =
+  'focus:brand-outline block w-full rounded-lg border border-(--input-border-color) p-3 text-(--color-text-base) placeholder:text-(--input-placeholder-color)'
+
+type TextInputFieldProps = {
+  name: string
+  label: string
+  type?: 'text' | 'email' | 'url'
+  required?: boolean
+  placeholder?: string
+  defaultValue?: string
+  autoComplete?: string
+  description?: string
+  error?: string
+}
+
+export function TextInputField({
+  name,
+  label,
+  type = 'text',
+  required,
+  placeholder,
+  defaultValue,
+  autoComplete,
+  description,
+  error,
+}: TextInputFieldProps) {
+  return (
+    <Field>
+      <Label className="text-(--color-text-base) text-sm font-medium mb-1 inline-block">
+        {label}
+        {required && (
+          <span aria-hidden="true" className="ml-0.5">
+            *
+          </span>
+        )}
+      </Label>
+      {description && (
+        <Description className="text-(--color-paragraph-text) text-sm mb-1 block">
+          {description}
+        </Description>
+      )}
+      <Input
+        name={name}
+        type={type}
+        required={required}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        autoComplete={autoComplete}
+        invalid={Boolean(error)}
+        aria-invalid={Boolean(error)}
+        className={inputClassName}
+      />
+      {error && <ErrorMessage message={error} />}
+    </Field>
+  )
+}

--- a/src/app/contact/components/TextInputField.tsx
+++ b/src/app/contact/components/TextInputField.tsx
@@ -1,4 +1,5 @@
 import { Description, Field, Input, Label } from '@headlessui/react'
+import { useId } from 'react'
 
 import { ErrorMessage } from '@/components/ErrorMessage'
 
@@ -28,6 +29,12 @@ export function TextInputField({
   description,
   error,
 }: TextInputFieldProps) {
+  const reactId = useId()
+  const descriptionId = description ? `${reactId}-description` : undefined
+  const errorId = error ? `${reactId}-error` : undefined
+  const describedBy =
+    [descriptionId, errorId].filter(Boolean).join(' ') || undefined
+
   return (
     <Field>
       <Label className="text-(--color-text-base) text-sm font-medium mb-1 inline-block">
@@ -39,7 +46,10 @@ export function TextInputField({
         )}
       </Label>
       {description && (
-        <Description className="text-(--color-paragraph-text) text-sm mb-1 block">
+        <Description
+          id={descriptionId}
+          className="text-(--color-paragraph-text) text-sm mb-1 block"
+        >
           {description}
         </Description>
       )}
@@ -52,9 +62,11 @@ export function TextInputField({
         autoComplete={autoComplete}
         invalid={Boolean(error)}
         aria-invalid={Boolean(error)}
+        aria-describedby={describedBy}
+        aria-errormessage={errorId}
         className={inputClassName}
       />
-      {error && <ErrorMessage message={error} />}
+      {error && <ErrorMessage id={errorId} message={error} />}
     </Field>
   )
 }

--- a/src/app/contact/components/TextareaField.tsx
+++ b/src/app/contact/components/TextareaField.tsx
@@ -1,0 +1,57 @@
+import { Description, Field, Label, Textarea } from '@headlessui/react'
+
+import { ErrorMessage } from '@/components/ErrorMessage'
+
+const textareaClassName =
+  'focus:brand-outline block w-full rounded-lg border border-(--input-border-color) p-3 text-(--color-text-base) placeholder:text-(--input-placeholder-color) resize-y min-h-32'
+
+type TextareaFieldProps = {
+  name: string
+  label: string
+  required?: boolean
+  placeholder?: string
+  defaultValue?: string
+  description?: string
+  error?: string
+  rows?: number
+}
+
+export function TextareaField({
+  name,
+  label,
+  required,
+  placeholder,
+  defaultValue,
+  description,
+  error,
+  rows = 5,
+}: TextareaFieldProps) {
+  return (
+    <Field>
+      <Label className="text-(--color-text-base) text-sm font-medium mb-1 inline-block">
+        {label}
+        {required && (
+          <span aria-hidden="true" className="ml-0.5">
+            *
+          </span>
+        )}
+      </Label>
+      {description && (
+        <Description className="text-(--color-paragraph-text) text-sm mb-1 block">
+          {description}
+        </Description>
+      )}
+      <Textarea
+        name={name}
+        rows={rows}
+        required={required}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        invalid={Boolean(error)}
+        aria-invalid={Boolean(error)}
+        className={textareaClassName}
+      />
+      {error && <ErrorMessage message={error} />}
+    </Field>
+  )
+}

--- a/src/app/contact/components/TextareaField.tsx
+++ b/src/app/contact/components/TextareaField.tsx
@@ -1,4 +1,5 @@
 import { Description, Field, Label, Textarea } from '@headlessui/react'
+import { useId } from 'react'
 
 import { ErrorMessage } from '@/components/ErrorMessage'
 
@@ -26,6 +27,12 @@ export function TextareaField({
   error,
   rows = 5,
 }: TextareaFieldProps) {
+  const reactId = useId()
+  const descriptionId = description ? `${reactId}-description` : undefined
+  const errorId = error ? `${reactId}-error` : undefined
+  const describedBy =
+    [descriptionId, errorId].filter(Boolean).join(' ') || undefined
+
   return (
     <Field>
       <Label className="text-(--color-text-base) text-sm font-medium mb-1 inline-block">
@@ -37,7 +44,10 @@ export function TextareaField({
         )}
       </Label>
       {description && (
-        <Description className="text-(--color-paragraph-text) text-sm mb-1 block">
+        <Description
+          id={descriptionId}
+          className="text-(--color-paragraph-text) text-sm mb-1 block"
+        >
           {description}
         </Description>
       )}
@@ -49,9 +59,11 @@ export function TextareaField({
         defaultValue={defaultValue}
         invalid={Boolean(error)}
         aria-invalid={Boolean(error)}
+        aria-describedby={describedBy}
+        aria-errormessage={errorId}
         className={textareaClassName}
       />
-      {error && <ErrorMessage message={error} />}
+      {error && <ErrorMessage id={errorId} message={error} />}
     </Field>
   )
 }

--- a/src/app/contact/config.ts
+++ b/src/app/contact/config.ts
@@ -1,23 +1,24 @@
 /**
  * Google Form integration for the contact form.
  *
- * To wire up: create the Google Form, then in the form editor click ⋮ → "Get
- * pre-filled link", fill every field with a unique placeholder, copy the URL,
- * and paste each `entry.NNNNNNNNNN=value` pair below.
+ * Form ID and entry IDs were extracted from the form's "Get pre-filled link"
+ * URL. To re-derive: open the form editor → ⋮ → "Get pre-filled link", fill
+ * each field with a unique placeholder, copy the URL, and read the
+ * `entry.NNNNNNNNNN` IDs from the query string.
  *
  * The submission URL ends in `/formResponse` (not `/viewform`).
  */
 export const GOOGLE_FORM_URL =
-  'https://docs.google.com/forms/d/e/REPLACE_WITH_FORM_ID/formResponse'
+  'https://docs.google.com/forms/d/e/1FAIpQLSeOzDuf9UflhT_dMKEa4lwmWL-JNrhjh6ot4bUd21HR4_f-PA/formResponse'
 
 export const GOOGLE_FORM_ENTRY_IDS = {
-  firstName: 'entry.0000000001',
-  lastName: 'entry.0000000002',
-  company: 'entry.0000000003',
-  email: 'entry.0000000004',
-  projectLink: 'entry.0000000005',
-  useCase: 'entry.0000000006',
-  optIn: 'entry.0000000007',
+  firstName: 'entry.1395415855',
+  lastName: 'entry.1610700810',
+  company: 'entry.2016790584',
+  email: 'entry.1961848032',
+  projectLink: 'entry.1001477030',
+  useCase: 'entry.1762795784',
+  optIn: 'entry.586019531',
 } as const
 
 export const IS_FORM_CONFIGURED = !GOOGLE_FORM_URL.includes('REPLACE_WITH')

--- a/src/app/contact/config.ts
+++ b/src/app/contact/config.ts
@@ -20,5 +20,3 @@ export const GOOGLE_FORM_ENTRY_IDS = {
   useCase: 'entry.1762795784',
   optIn: 'entry.586019531',
 } as const
-
-export const IS_FORM_CONFIGURED = !GOOGLE_FORM_URL.includes('REPLACE_WITH')

--- a/src/app/contact/config.ts
+++ b/src/app/contact/config.ts
@@ -1,0 +1,23 @@
+/**
+ * Google Form integration for the contact form.
+ *
+ * To wire up: create the Google Form, then in the form editor click ⋮ → "Get
+ * pre-filled link", fill every field with a unique placeholder, copy the URL,
+ * and paste each `entry.NNNNNNNNNN=value` pair below.
+ *
+ * The submission URL ends in `/formResponse` (not `/viewform`).
+ */
+export const GOOGLE_FORM_URL =
+  'https://docs.google.com/forms/d/e/REPLACE_WITH_FORM_ID/formResponse'
+
+export const GOOGLE_FORM_ENTRY_IDS = {
+  firstName: 'entry.0000000001',
+  lastName: 'entry.0000000002',
+  company: 'entry.0000000003',
+  email: 'entry.0000000004',
+  projectLink: 'entry.0000000005',
+  useCase: 'entry.0000000006',
+  optIn: 'entry.0000000007',
+} as const
+
+export const IS_FORM_CONFIGURED = !GOOGLE_FORM_URL.includes('REPLACE_WITH')

--- a/src/app/contact/constants/seo.ts
+++ b/src/app/contact/constants/seo.ts
@@ -1,0 +1,5 @@
+export const CONTACT_SEO = {
+  title: 'Talk to our team | Filecoin Onchain Cloud',
+  description:
+    'Tell us about your use case and the Filecoin Onchain Cloud team will get back to you. For builders, founders, and partners exploring onchain storage, payments, and verifiability.',
+} as const

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,46 @@
+import { Container } from '@filecoin-foundation/ui-filecoin/Container'
+import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
+import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
+
+import { Navigation } from '@/components/Navigation/Navigation'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import { createMetadata } from '@/utils/create-metadata'
+
+import { ContactForm } from './components/ContactForm'
+import { CONTACT_SEO } from './constants/seo'
+import { generateStructuredData } from './utils/generate-structured-data'
+
+export default function Contact() {
+  return (
+    <>
+      <StructuredDataScript
+        structuredData={generateStructuredData(CONTACT_SEO)}
+      />
+
+      <Navigation backgroundVariant="light" />
+      <PageSection backgroundVariant="light">
+        <PageHeader
+          centered
+          title="Talk to our team"
+          description="Tell us about your use case and we'll get back to you shortly."
+        />
+      </PageSection>
+
+      <PageSection backgroundVariant="light" paddingVariant="topNone">
+        <Container>
+          <div className="mx-auto max-w-2xl">
+            <ContactForm />
+          </div>
+        </Container>
+      </PageSection>
+    </>
+  )
+}
+
+export const metadata = createMetadata({
+  title: CONTACT_SEO.title,
+  description: CONTACT_SEO.description,
+  path: PATHS.CONTACT.path,
+})

--- a/src/app/contact/utils/generate-structured-data.ts
+++ b/src/app/contact/utils/generate-structured-data.ts
@@ -1,0 +1,16 @@
+import type { WebPageGraph } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import type { StructuredDataParams } from '@/types/structured-data-params'
+import { generatePageStructuredData } from '@/utils/generate-page-structured-data'
+
+export function generateStructuredData(
+  seo: StructuredDataParams,
+): WebPageGraph {
+  return generatePageStructuredData({
+    title: seo.title,
+    description: seo.description,
+    path: PATHS.CONTACT.path,
+    pageType: 'ContactPage',
+  })
+}

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,10 +1,11 @@
 type ErrorMessageProps = {
   message: string
+  id?: string
 }
 
-export function ErrorMessage({ message }: ErrorMessageProps) {
+export function ErrorMessage({ message, id }: ErrorMessageProps) {
   return (
-    <p className="text-(--color-brand-error) text-sm pt-2" role="alert">
+    <p id={id} className="text-(--color-brand-error) text-sm pt-2" role="alert">
       {message}
     </p>
   )

--- a/src/components/Navigation/constants/navigation.ts
+++ b/src/components/Navigation/constants/navigation.ts
@@ -38,6 +38,10 @@ export const headerNavigationItems: Array<NavItem | NavigationMenuItem> = [
     label: 'Documentation',
     href: FOC_URLS.documentation.home,
   },
+  {
+    label: PATHS.CONTACT.label,
+    href: PATHS.CONTACT.path,
+  },
 ]
 
 export const mobileNavigationItems: Array<NavItem> = [
@@ -60,5 +64,9 @@ export const mobileNavigationItems: Array<NavItem> = [
   {
     label: 'Documentation',
     href: FOC_URLS.documentation.home,
+  },
+  {
+    label: PATHS.CONTACT.label,
+    href: PATHS.CONTACT.path,
   },
 ]

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -10,6 +10,10 @@ export const PATHS = {
     path: '/agents',
     label: 'Agents',
   },
+  CONTACT: {
+    path: '/contact',
+    label: 'Talk to our team',
+  },
   HOMEPAGE: {
     path: '/',
     label: 'Homepage',


### PR DESCRIPTION
## Summary
- Adds `/contact` route following site conventions: `Navigation` + `PageSection` + `PageHeader`, per-page SEO + structured data, `createMetadata`, sitemap auto-included via `PATHS`.
- Form modelled on [fil.one/contact-sales](https://fil.one/contact-sales). Fields: first / last name, company or project, work email, GitHub repo or project link (optional), use case (textarea), marketing opt-in. Submit uses ui-filecoin `Button` `primary`.
- Wired with React 19 `useActionState` + Server Action (`src/app/contact/actions.ts`). Required-field validation, inline field errors, pending submit state, success state replaces the form. Submissions POST to a Google Form `formResponse` endpoint; opt-in is sent using the form's exact checkbox option label (Google Forms requires the literal string).
- Adds secondary "Talk to our team" CTA on the homepage hero next to "Start building" (ghost variant with overridden border/bg for visual pairing on the dark hero).
- Adds "Talk to our team" to the desktop header nav and the mobile menu.
- Accessibility: each field's error and description ids are wired via `aria-describedby` / `aria-errormessage` so screen readers announce errors on focus.
- Network errors and non-2xx responses from Google Forms surface as a user-visible error rather than a silent success.

## Test plan
- [x] Vercel preview loads `/contact` with the styled form
- [x] Submitting with empty required fields shows inline errors
- [x] Submitting with valid data shows the success state
- [x] Submission lands in the Google Form's Responses tab (verified via curl + UI)
- [x] Homepage hero shows both "Start building" and "Talk to our team" buttons
- [x] "Talk to our team" appears in the header nav and mobile menu
- [x] `/contact` appears in `/sitemap.xml`