### PR TITLE
fix: unbreak /service-providers (RPC + resilient validation)

### DIFF
--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -66,7 +66,7 @@ const mainnet: Chain = {
   },
   rpcUrls: {
     default: {
-      http: ['https://filecoin.chain.love/'],
+      http: ['https://api.node.glif.io/'],
       webSocket: ['wss://wss.node.glif.io/apigw/lotus/rpc/v1'],
     },
   },

--- a/src/services/providers/index.ts
+++ b/src/services/providers/index.ts
@@ -11,10 +11,7 @@ import type {
 } from '@/config/abis'
 import { getChain, type Network } from '@/config/chains'
 import { getPublicClient } from '@/config/client'
-import {
-  providersSchema,
-  type ServiceProvider,
-} from '@/schemas/provider-schema'
+import { providerSchema, type ServiceProvider } from '@/schemas/provider-schema'
 import type { FetchProvidersOptions, ProviderFilter } from '@/types/providers'
 import { getCheckActivityUrl } from '@/utils/provider-urls'
 
@@ -124,15 +121,19 @@ async function enrichProviders(
     providersWithVersions.push(...batchResults)
   }
 
-  const result = providersSchema.safeParse(providersWithVersions)
-  if (!result.success) {
-    console.error('Provider validation failed:', {
-      errors: result.error.issues,
-      providers: providersWithVersions.map((p) => ({ id: p.id, name: p.name })),
-    })
-    throw new Error(`Provider validation failed: ${result.error.message}`)
+  const valid: ServiceProvider[] = []
+  for (const provider of providersWithVersions) {
+    const result = providerSchema.safeParse(provider)
+    if (result.success) {
+      valid.push(result.data)
+    } else {
+      console.warn(
+        `Skipping malformed provider ${provider.id} (${provider.name}):`,
+        result.error.issues,
+      )
+    }
   }
-  return result.data
+  return valid
 }
 
 /**


### PR DESCRIPTION
## 📝 Description

`/service-providers` is currently failing in production. Two issues, both surfaced today via the [Slack thread](https://filecoinproject.slack.com/archives/C0AD46X6VEG/p1778170397055489).

**1. Mainnet RPC** (`src/config/chains.ts`)

`viem` was failing with `Failed to fetch` against `https://filecoin.chain.love/`. `api.node.glif.io` and `filecoin.chain.love` resolve to the same backend IP and `GET /` 301s between them, so #284 looked like a redirect normalization. But viem submits `POST /` with a JSON-RPC body, which doesn't follow the redirect — the browser hits chain.love directly, and that's where the flake is. Reverts to `https://api.node.glif.io/` (state restored from `9678ab9` before #284 / `489af63`).

**2. Provider validation** (`src/services/providers/index.ts`)

Provider 28 (`reiers.io`) registered today with `serviceURL: "https:"` (literal 6 bytes, no host). `providersSchema.safeParse(array)` rejects the whole array on any single failure, so one bad on-chain registration takes down the entire page. Switches to per-provider `safeParse` — invalid rows are logged and skipped, valid rows render.

- **Type:** Bug fix

## 🛠️ Key Changes

- `src/config/chains.ts`: mainnet `rpcUrls.default.http[0]` reverted from `https://filecoin.chain.love/` to `https://api.node.glif.io/`. WebSocket URL and calibnet config unchanged.
- `src/services/providers/index.ts`: replace bulk `providersSchema.safeParse` with a per-provider `providerSchema.safeParse` loop; log + skip invalid providers via `console.warn`.

## 📌 To-Do Before Merging

- [ ] Vercel preview `/service-providers` loads and renders the SP list against mainnet
- [ ] Provider 28 (`reiers.io`) is absent from the rendered list (skipped)
- [ ] Browser console shows `Skipping malformed provider 28 (reiers.io)` warning
- [ ] No viem `Failed to fetch` errors on `getApprovedProvidersLength()`