### PR TITLE
feat: add status page link to site navigation

### DIFF
--- a/src/components/Navigation/constants/navigation.ts
+++ b/src/components/Navigation/constants/navigation.ts
@@ -39,6 +39,10 @@ export const headerNavigationItems: Array<NavItem | NavigationMenuItem> = [
     href: FOC_URLS.documentation.home,
   },
   {
+    label: 'Status',
+    href: FOC_URLS.status,
+  },
+  {
     label: PATHS.CONTACT.label,
     href: PATHS.CONTACT.path,
   },
@@ -64,6 +68,10 @@ export const mobileNavigationItems: Array<NavItem> = [
   {
     label: 'Documentation',
     href: FOC_URLS.documentation.home,
+  },
+  {
+    label: 'Status',
+    href: FOC_URLS.status,
   },
   {
     label: PATHS.CONTACT.label,

--- a/src/constants/site-metadata.ts
+++ b/src/constants/site-metadata.ts
@@ -39,6 +39,7 @@ const FOC_URLS = {
     repository: 'https://github.com/FilOzone/filecoin-cloud',
   },
   filecoinPay: 'https://pay.filecoin.cloud/mainnet',
+  status: 'https://status.filoz.org',
   payments: {
     contractSourceCode:
       'https://github.com/FilOzone/filecoin-pay/tree/main/src',


### PR DESCRIPTION
Closes #283

## 📝 Description

- Adds a visible `Status` link to the global navigation
- Includes the link in both desktop and mobile navigation
- Points to `https://status.filoz.org`

## 📌 To-Do Before Merging

- [x] review Vercel-deployment 

## 📸 Screenshots

See comment below: https://github.com/FilOzone/filecoin-cloud/pull/307#issuecomment-4437807812
