### PR TITLE
feat(contact): Cloudflare Turnstile + honeypot spam protection

### DIFF
--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -1,6 +1,15 @@
 'use server'
 
-import { GOOGLE_FORM_ENTRY_IDS, GOOGLE_FORM_URL } from './config'
+import { headers } from 'next/headers'
+
+import {
+  GOOGLE_FORM_ENTRY_IDS,
+  GOOGLE_FORM_URL,
+  HONEYPOT_FIELD_NAME,
+  TURNSTILE_VERIFY_URL,
+} from './config'
+
+const TURNSTILE_TEST_SECRET_PASS = '1x0000000000000000000000000000000AA'
 
 export type ContactFormState = {
   status: 'idle' | 'success' | 'error'
@@ -40,6 +49,13 @@ export async function submitContact(
     optIn: formData.get('optIn') === 'on',
   }
 
+  if (getString(formData, HONEYPOT_FIELD_NAME)) {
+    return {
+      status: 'success',
+      message: "Thanks — we'll be in touch shortly.",
+    }
+  }
+
   const fieldErrors: ContactFormState['fieldErrors'] = {}
   for (const field of REQUIRED_FIELDS) {
     if (!values[field]) {
@@ -52,6 +68,11 @@ export async function submitContact(
 
   if (Object.keys(fieldErrors).length > 0) {
     return { status: 'error', fieldErrors }
+  }
+
+  const turnstileError = await verifyTurnstile(formData)
+  if (turnstileError) {
+    return turnstileError
   }
 
   const body = new URLSearchParams({
@@ -103,4 +124,57 @@ export async function submitContact(
 function getString(formData: FormData, key: string): string {
   const value = formData.get(key)
   return typeof value === 'string' ? value.trim() : ''
+}
+
+async function verifyTurnstile(
+  formData: FormData,
+): Promise<ContactFormState | null> {
+  const token = getString(formData, 'cf-turnstile-response')
+  if (!token) {
+    return {
+      status: 'error',
+      message: 'Please complete the verification challenge before submitting.',
+    }
+  }
+
+  const secret = process.env.TURNSTILE_SECRET_KEY ?? TURNSTILE_TEST_SECRET_PASS
+  const verifyBody = new URLSearchParams({ secret, response: token })
+
+  const forwardedFor = (await headers()).get('x-forwarded-for')
+  const remoteIp = forwardedFor?.split(',')[0]?.trim()
+  if (remoteIp) {
+    verifyBody.append('remoteip', remoteIp)
+  }
+
+  try {
+    const response = await fetch(TURNSTILE_VERIFY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: verifyBody,
+    })
+    const result = (await response.json()) as {
+      success: boolean
+      'error-codes'?: Array<string>
+    }
+    if (!result.success) {
+      console.warn(
+        '[contact] Turnstile verification failed:',
+        result['error-codes'],
+      )
+      return {
+        status: 'error',
+        message:
+          'Verification failed. Please reload the page and try submitting again.',
+      }
+    }
+  } catch (error) {
+    console.error('[contact] Turnstile verification request errored:', error)
+    return {
+      status: 'error',
+      message:
+        'Verification could not be completed. Please reload the page and try submitting again.',
+    }
+  }
+
+  return null
 }

--- a/src/app/contact/components/ContactForm.tsx
+++ b/src/app/contact/components/ContactForm.tsx
@@ -4,6 +4,7 @@ import { Button } from '@filecoin-foundation/ui-filecoin/Button'
 import { Checkbox } from '@filecoin-foundation/ui-filecoin/Checkbox'
 import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
 import { Field, Label } from '@headlessui/react'
+import Script from 'next/script'
 import { useActionState, useState } from 'react'
 
 import { PATHS } from '@/constants/paths'
@@ -11,6 +12,11 @@ import { PATHS } from '@/constants/paths'
 import { TextareaField } from './TextareaField'
 import { TextInputField } from './TextInputField'
 import { type ContactFormState, submitContact } from '../actions'
+import {
+  HONEYPOT_FIELD_NAME,
+  TURNSTILE_SCRIPT_URL,
+  TURNSTILE_SITE_KEY,
+} from '../config'
 
 const INITIAL_STATE: ContactFormState = { status: 'idle' }
 
@@ -36,6 +42,22 @@ export function ContactForm() {
 
   return (
     <form action={formAction} className="space-y-6" noValidate>
+      <Script src={TURNSTILE_SCRIPT_URL} strategy="afterInteractive" async />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -left-[9999px] h-px w-px overflow-hidden"
+      >
+        <label htmlFor={HONEYPOT_FIELD_NAME}>
+          Leave this field blank
+          <input
+            id={HONEYPOT_FIELD_NAME}
+            name={HONEYPOT_FIELD_NAME}
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+          />
+        </label>
+      </div>
       <div className="grid gap-6 sm:grid-cols-2">
         <TextInputField
           name="firstName"
@@ -112,6 +134,12 @@ export function ContactForm() {
         </ExternalTextLink>
         .
       </p>
+
+      <div
+        className="cf-turnstile"
+        data-sitekey={TURNSTILE_SITE_KEY}
+        data-appearance="always"
+      />
 
       {state.status === 'error' && state.message && !state.fieldErrors && (
         <p role="alert" className="text-(--color-brand-error) text-sm">

--- a/src/app/contact/config.ts
+++ b/src/app/contact/config.ts
@@ -20,3 +20,30 @@ export const GOOGLE_FORM_ENTRY_IDS = {
   useCase: 'entry.1762795784',
   optIn: 'entry.586019531',
 } as const
+
+/**
+ * Cloudflare Turnstile (managed mode) — spam protection for the contact form.
+ *
+ * Production keys come from environment variables on Vercel. Locally, falls
+ * back to Cloudflare's published "always passes" test keys so the form can be
+ * exercised without a real widget. To test the failure path locally, set
+ * `TURNSTILE_SECRET_KEY=2x0000000000000000000000000000000AA` and
+ * `NEXT_PUBLIC_TURNSTILE_SITE_KEY=2x00000000000000000000AB`.
+ *
+ * See: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+ */
+export const TURNSTILE_SITE_KEY =
+  process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '1x00000000000000000000AA'
+
+export const TURNSTILE_VERIFY_URL =
+  'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+export const TURNSTILE_SCRIPT_URL =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js'
+
+/**
+ * Hidden honeypot input name. Real users never see or fill this field; bots
+ * that auto-complete every input will, and submissions with a non-empty value
+ * are silently accepted (without forwarding to Google Forms).
+ */
+export const HONEYPOT_FIELD_NAME = 'website'


### PR DESCRIPTION
## 📝 Description

The `/contact` form is currently being hit with a steady volume of spam submissions. This PR adds a two-layer defence with minimal user friction:

1. **Offscreen honeypot field** — bots that autofill every input fill it; humans never see it. Submissions with a non-empty honeypot value silently return success without forwarding to the Google Form, so the bot believes it succeeded and stops retrying.
2. **Cloudflare Turnstile (managed mode)** — visible widget that auto-solves for most humans with a "verifying… ✓" tick, and surfaces an interactive challenge only when Cloudflare's risk model warrants. The token is verified server-side inside the Server Action before the Google Forms POST is made.

- **Type:** feat

## 🔍 Preview

Live preview deploy (with production Turnstile keys + widget): https://filecoin-cloud-git-fork-tippyflitsuk-feat-contact-fd5339-filoz.vercel.app/contact

## 🛠️ Key Changes

- `src/app/contact/config.ts` — new exports: `TURNSTILE_SITE_KEY`, `TURNSTILE_VERIFY_URL`, `TURNSTILE_SCRIPT_URL`, `HONEYPOT_FIELD_NAME`. Falls back to Cloudflare's documented "always passes" test keys so local dev works without setting env vars.
- `src/app/contact/actions.ts` — adds honeypot short-circuit + `verifyTurnstile()` helper that POSTs to siteverify with `secret`, `response`, and `remoteip` (read from `x-forwarded-for` via async `headers()`). Order: honeypot → field validation → Turnstile → Google Forms submit. Field validation runs before Turnstile so users fixing typos don't burn their token.
- `src/app/contact/components/ContactForm.tsx` — loads the Turnstile script via `next/script` with `strategy="afterInteractive"`, renders the implicit widget (`<div class="cf-turnstile" data-sitekey=... data-appearance="always">`) above the submit button, and adds a visually-hidden honeypot input (offscreen, `aria-hidden`, `tabIndex={-1}`, `autoComplete="off"`).

The `/contact` route remains statically prerendered; `headers()` is only invoked when the Server Action fires.

## 📌 To-Do Before Merging

- [ ] Create a managed-mode widget in the Cloudflare dashboard for `filecoin.cloud` (+ `*.vercel.app` if preview testing is desired).
- [ ] Add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (production + preview) and `TURNSTILE_SECRET_KEY` (production + preview) on the Vercel project. Without these, the widget falls back to Cloudflare's always-pass test keys which provide no protection.
- [ ] Verify on a preview deploy that the widget renders, real submissions land in the response sheet, and honeypot-set submissions do not.

## 🧪 Verification

- `npm run lint` — clean
- `npm run build` — green; `/contact` still prerendered as static
- Local Turnstile flow exercised with Cloudflare's `1x...` always-pass test keys (default fallback).
- Failure path exercisable locally by setting `TURNSTILE_SECRET_KEY=2x0000000000000000000000000000000AA` + `NEXT_PUBLIC_TURNSTILE_SITE_KEY=2x00000000000000000000AB`.

## ℹ️ Note on CI

The `Add all issues and prs to project` workflow shows as failed. This is unrelated to this PR — the workflow requires a repo secret (`FILOZZY_CI_ADD_TO_PROJECT`) that GitHub does not expose to fork PRs by design. It fails the same way on every fork PR. The PR can be added to the FS project board manually after merge.