### PR TITLE
feat: add guidance for FOC support paths.

### DIFF
--- a/src/app/(homepage)/data/developer-resources.ts
+++ b/src/app/(homepage)/data/developer-resources.ts
@@ -1,8 +1,10 @@
 import type { LinkCardData } from '@filecoin-foundation/ui-filecoin/LinkCard'
 import {
   BookOpenIcon,
+  GithubLogoIcon,
   GlobeIcon,
-  TelegramLogoIcon,
+  PulseIcon,
+  SlackLogoIcon,
   YoutubeLogoIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
@@ -20,13 +22,23 @@ export const developerResources = [
     icon: BookOpenIcon,
   },
   {
+    title: 'Join #fil-foc on Slack',
+    href: FOC_URLS.social.slack,
+    icon: SlackLogoIcon,
+  },
+  {
+    title: 'Report a FOC problem',
+    href: FOC_URLS.filecoinCloud.problemReports,
+    icon: GithubLogoIcon,
+  },
+  {
+    title: 'Check service status',
+    href: FOC_URLS.status,
+    icon: PulseIcon,
+  },
+  {
     title: 'Explore our YouTube playlist',
     href: 'https://www.youtube.com/watch?v=0oD0J-4lIXg&list=PL_0VrY55uV181dWs7RfIpx0ZAUZeNMjE1',
     icon: YoutubeLogoIcon,
-  },
-  {
-    title: 'Join the community',
-    href: FOC_URLS.social.telegram,
-    icon: TelegramLogoIcon,
   },
 ] as const satisfies Array<LinkCardData>

--- a/src/app/(homepage)/data/faqs.tsx
+++ b/src/app/(homepage)/data/faqs.tsx
@@ -158,6 +158,37 @@ export const faqs: Array<Question> = [
     ),
   },
   {
+    question: 'Where can I get help or report a problem?',
+    answer: (
+      <>
+        <p>Use the channel that matches what you need:</p>
+        <ul>
+          <li>
+            For real-time troubleshooting, jump into the{' '}
+            <MarkdownLink href={FOC_URLS.social.slack}>
+              #fil-foc channel on Filecoin Slack
+            </MarkdownLink>
+            .
+          </li>
+          <li>
+            For reproducible bugs or persistent issues,{' '}
+            <MarkdownLink href={FOC_URLS.filecoinCloud.problemReports}>
+              report a FOC problem on GitHub
+            </MarkdownLink>{' '}
+            so the team can triage it without losing the context.
+          </li>
+          <li>
+            For outages or active incidents, check the{' '}
+            <MarkdownLink href={FOC_URLS.status}>
+              Filecoin Cloud status page
+            </MarkdownLink>
+            .
+          </li>
+        </ul>
+      </>
+    ),
+  },
+  {
     question: 'How can I get involved with the community?',
     answer: (
       <>

--- a/src/app/(homepage)/data/faqs.tsx
+++ b/src/app/(homepage)/data/faqs.tsx
@@ -199,12 +199,12 @@ export const faqs: Array<Question> = [
             <MarkdownLink href={FOC_URLS.social.telegram}>
               FOC Builders group on Telegram
             </MarkdownLink>{' '}
-            to ask questions and get support.
+            to meet other builders.
           </li>
           <li>
             Jump into the{' '}
             <MarkdownLink href={FOC_URLS.social.slack}>
-              #FIL-FOC channel on Filecoin Slack
+              #fil-foc channel on Filecoin Slack
             </MarkdownLink>
             .
           </li>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,6 +2,7 @@ import { Container } from '@filecoin-foundation/ui-filecoin/Container'
 import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
 import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
 import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
+import { SmartTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/SmartTextLink'
 
 import { Navigation } from '@/components/Navigation/Navigation'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
@@ -47,6 +48,13 @@ export default function Contact() {
                   </h2>
                   <p className="text-(--color-paragraph-text)">
                     Use the channel that best matches what you need.
+                  </p>
+                  <p className="text-(--color-paragraph-text)">
+                    For the full list of support and community channels, see the{' '}
+                    <SmartTextLink href={PATHS.SUPPORT.path}>
+                      Support page
+                    </SmartTextLink>
+                    .
                   </p>
                 </div>
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,11 +1,13 @@
 import { Container } from '@filecoin-foundation/ui-filecoin/Container'
 import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
 import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
+import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
 
 import { Navigation } from '@/components/Navigation/Navigation'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { PATHS } from '@/constants/paths'
+import { FOC_URLS } from '@/constants/site-metadata'
 import { createMetadata } from '@/utils/create-metadata'
 
 import { ContactForm } from './components/ContactForm'
@@ -30,7 +32,66 @@ export default function Contact() {
 
       <PageSection backgroundVariant="light" paddingVariant="topNone">
         <Container>
-          <div className="mx-auto max-w-2xl">
+          <div className="mx-auto max-w-2xl space-y-10">
+            <section
+              aria-labelledby="technical-support-heading"
+              className="border-y border-(--color-border-base) py-8"
+            >
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <h2
+                    id="technical-support-heading"
+                    className="font-semibold text-2xl text-(--color-text-base)"
+                  >
+                    Need technical support?
+                  </h2>
+                  <p className="text-(--color-paragraph-text)">
+                    Use the channel that best matches what you need.
+                  </p>
+                </div>
+
+                <ul className="space-y-3 text-(--color-paragraph-text)">
+                  <li>
+                    <strong className="font-medium text-(--color-text-base)">
+                      Quick troubleshooting:
+                    </strong>{' '}
+                    join the{' '}
+                    <ExternalTextLink href={FOC_URLS.social.slack}>
+                      #fil-foc channel on Filecoin Slack
+                    </ExternalTextLink>
+                    .
+                  </li>
+                  <li>
+                    <strong className="font-medium text-(--color-text-base)">
+                      Reproducible or persistent problems:
+                    </strong>{' '}
+                    <ExternalTextLink
+                      href={FOC_URLS.filecoinCloud.problemReports}
+                    >
+                      report a FOC problem on GitHub
+                    </ExternalTextLink>
+                    .
+                  </li>
+                  <li>
+                    <strong className="font-medium text-(--color-text-base)">
+                      Outages or active incidents:
+                    </strong>{' '}
+                    check the{' '}
+                    <ExternalTextLink href={FOC_URLS.status}>
+                      Filecoin Cloud status page
+                    </ExternalTextLink>
+                    .
+                  </li>
+                  <li>
+                    <strong className="font-medium text-(--color-text-base)">
+                      Use cases or product feedback:
+                    </strong>{' '}
+                    send the team a note below.
+                  </li>
+                </ul>
+              </div>
+            </section>
+
             <ContactForm />
           </div>
         </Container>

--- a/src/app/support/constants/seo.ts
+++ b/src/app/support/constants/seo.ts
@@ -1,0 +1,5 @@
+export const SUPPORT_SEO = {
+  title: 'Support | Filecoin Onchain Cloud',
+  description:
+    'Find the right support channel for Filecoin Onchain Cloud, including real-time chat, community discussion, problem reports, service status, and product feedback.',
+} as const

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,110 @@
+import { CardGrid } from '@filecoin-foundation/ui-filecoin/CardGrid'
+import { Container } from '@filecoin-foundation/ui-filecoin/Container'
+import { LinkCard } from '@filecoin-foundation/ui-filecoin/LinkCard'
+import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
+import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
+import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
+import {
+  ChatCircleIcon,
+  GithubLogoIcon,
+  LightbulbIcon,
+  PulseIcon,
+  TelegramLogoIcon,
+} from '@phosphor-icons/react/dist/ssr'
+
+import { Navigation } from '@/components/Navigation/Navigation'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import { FOC_URLS } from '@/constants/site-metadata'
+import { createMetadata } from '@/utils/create-metadata'
+
+import { SUPPORT_SEO } from './constants/seo'
+import { generateStructuredData } from './utils/generate-structured-data'
+
+const supportOptions = [
+  {
+    title: 'Quick troubleshooting',
+    description:
+      'Use #fil-foc on Filecoin Slack when you are stuck and need fast back-and-forth with the team or other builders.',
+    href: FOC_URLS.social.slack,
+    icon: ChatCircleIcon,
+  },
+  {
+    title: 'Join the builder community',
+    description:
+      'Use the FOC Builders Telegram group for community discussion, ideas, and updates with other builders.',
+    href: FOC_URLS.social.telegram,
+    icon: TelegramLogoIcon,
+  },
+  {
+    title: 'Report a FOC problem',
+    description:
+      'Use the public GitHub intake form for reproducible bugs or persistent issues so context stays searchable and triageable.',
+    href: FOC_URLS.filecoinCloud.problemReports,
+    icon: GithubLogoIcon,
+  },
+  {
+    title: 'Check service status',
+    description:
+      'Use the status page for outages, active incidents, and high-level service availability updates.',
+    href: FOC_URLS.status,
+    icon: PulseIcon,
+  },
+  {
+    title: 'Share your use case',
+    description:
+      'Use the contact form for product feedback, partnerships, and ideas about what you want to build with Filecoin Onchain Cloud.',
+    href: PATHS.CONTACT.path,
+    icon: LightbulbIcon,
+  },
+] as const
+
+export default function Support() {
+  return (
+    <>
+      <StructuredDataScript
+        structuredData={generateStructuredData(SUPPORT_SEO)}
+      />
+
+      <Navigation backgroundVariant="light" />
+      <PageSection backgroundVariant="light">
+        <PageHeader
+          centered
+          title="Support"
+          description="Find the right channel for Filecoin Onchain Cloud help, community discussion, problem reports, service status, and product feedback."
+        />
+      </PageSection>
+
+      <PageSection backgroundVariant="light" paddingVariant="topNone">
+        <Container>
+          <SectionContent
+            headingTag="h2"
+            title="Choose the best path"
+            description="Different requests need different channels. Start here so the team can respond in the place that fits the work."
+          >
+            <CardGrid as="ul" variant="mdTwo">
+              {supportOptions.map(({ title, description, href, icon }) => (
+                <LinkCard
+                  key={title}
+                  as="li"
+                  title={title}
+                  headingTag="h3"
+                  description={description}
+                  href={href}
+                  icon={{ component: icon, variant: 'filled' }}
+                />
+              ))}
+            </CardGrid>
+          </SectionContent>
+        </Container>
+      </PageSection>
+    </>
+  )
+}
+
+export const metadata = createMetadata({
+  title: SUPPORT_SEO.title,
+  description: SUPPORT_SEO.description,
+  path: PATHS.SUPPORT.path,
+})

--- a/src/app/support/utils/generate-structured-data.ts
+++ b/src/app/support/utils/generate-structured-data.ts
@@ -1,0 +1,16 @@
+import type { WebPageGraph } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import type { StructuredDataParams } from '@/types/structured-data-params'
+import { generatePageStructuredData } from '@/utils/generate-page-structured-data'
+
+export function generateStructuredData(
+  seo: StructuredDataParams,
+): WebPageGraph {
+  return generatePageStructuredData({
+    title: seo.title,
+    description: seo.description,
+    path: PATHS.SUPPORT.path,
+    pageType: 'WebPage',
+  })
+}

--- a/src/components/Navigation/constants/navigation.ts
+++ b/src/components/Navigation/constants/navigation.ts
@@ -26,6 +26,11 @@ export const headerNavigationItems: Array<NavItem | NavigationMenuItem> = [
             label: PATHS.AGENTS.label,
             href: PATHS.AGENTS.path,
           },
+          {
+            description: 'Find the right support channel for FOC',
+            label: PATHS.SUPPORT.label,
+            href: PATHS.SUPPORT.path,
+          },
         ],
       },
     ],
@@ -72,6 +77,10 @@ export const mobileNavigationItems: Array<NavItem> = [
   {
     label: 'Status',
     href: FOC_URLS.status,
+  },
+  {
+    label: PATHS.SUPPORT.label,
+    href: PATHS.SUPPORT.path,
   },
   {
     label: PATHS.CONTACT.label,

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -26,6 +26,10 @@ export const PATHS = {
     path: '/service-providers',
     label: 'Service Providers',
   },
+  SUPPORT: {
+    path: '/support',
+    label: 'Support',
+  },
   TERMS_OF_USE: {
     path: '/terms-of-use',
     label: 'Terms of Use',

--- a/src/constants/site-metadata.ts
+++ b/src/constants/site-metadata.ts
@@ -36,6 +36,8 @@ const FOC_URLS = {
       'https://docs.filecoin.cloud/core-concepts/pdp-overview/',
   },
   filecoinCloud: {
+    problemReports:
+      'https://github.com/FilOzone/foc-problems/issues/new/choose',
     repository: 'https://github.com/FilOzone/filecoin-cloud',
   },
   filecoinPay: 'https://pay.filecoin.cloud/mainnet',


### PR DESCRIPTION
## 📝 Description

Closes: https://github.com/FilOzone/filecoin-cloud/issues/264

Adds clearer public guidance for Filecoin Onchain Cloud support paths.

- Adds a canonical FOC_URLS.filecoinCloud.problemReports link to the FilOzone/foc-problems GitHub issue form.
- Adds a homepage FAQ entry explaining which channel to use for:
   - real-time troubleshooting: #fil-foc on Filecoin Slack
   - persistent/reproducible problems: GitHub problem report
   - outages/incidents: Filecoin Cloud status page
- Updates homepage resource cards to surface Slack, problem reporting, and service status directly.

## 📸 Screenshots

Before: 
<img width="849" height="774" alt="filecoin-cloud-support-before" src="https://github.com/user-attachments/assets/9953bde6-12a7-4f17-92cc-248aa6796cf3" />

After:
<img width="849" height="972" alt="filecoin-cloud-support-after" src="https://github.com/user-attachments/assets/8bd92f84-0997-46c7-943d-02c2a867089a" />

<img width="1048" height="300" alt="Screenshot 2026-05-21 at 07 59 23" src="https://github.com/user-attachments/assets/6e8ce1e6-b08e-4b3e-bb03-6154dd4300ed" />
