### PR TITLE
feat: add support page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,6 +2,7 @@ import { Container } from '@filecoin-foundation/ui-filecoin/Container'
 import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
 import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
 import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
+import { SmartTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/SmartTextLink'
 
 import { Navigation } from '@/components/Navigation/Navigation'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
@@ -47,6 +48,13 @@ export default function Contact() {
                   </h2>
                   <p className="text-(--color-paragraph-text)">
                     Use the channel that best matches what you need.
+                  </p>
+                  <p className="text-(--color-paragraph-text)">
+                    For the full list of support and community channels, see the{' '}
+                    <SmartTextLink href={PATHS.SUPPORT.path}>
+                      Support page
+                    </SmartTextLink>
+                    .
                   </p>
                 </div>
 

--- a/src/app/support/constants/seo.ts
+++ b/src/app/support/constants/seo.ts
@@ -1,5 +1,5 @@
 export const SUPPORT_SEO = {
   title: 'Support | Filecoin Onchain Cloud',
   description:
-    'Find the right support channel for Filecoin Onchain Cloud, including real-time chat, problem reports, service status, and product feedback.',
+    'Find the right support channel for Filecoin Onchain Cloud, including real-time chat, community discussion, problem reports, service status, and product feedback.',
 } as const

--- a/src/app/support/constants/seo.ts
+++ b/src/app/support/constants/seo.ts
@@ -1,0 +1,5 @@
+export const SUPPORT_SEO = {
+  title: 'Support | Filecoin Onchain Cloud',
+  description:
+    'Find the right support channel for Filecoin Onchain Cloud, including real-time chat, problem reports, service status, and product feedback.',
+} as const

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -9,6 +9,7 @@ import {
   GithubLogoIcon,
   LightbulbIcon,
   PulseIcon,
+  TelegramLogoIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 import { Navigation } from '@/components/Navigation/Navigation'
@@ -28,6 +29,13 @@ const supportOptions = [
       'Use #fil-foc on Filecoin Slack when you are stuck and need fast back-and-forth with the team or other builders.',
     href: FOC_URLS.social.slack,
     icon: ChatCircleIcon,
+  },
+  {
+    title: 'Join the builder community',
+    description:
+      'Use the FOC Builders Telegram group for community discussion, ideas, and updates with other builders.',
+    href: FOC_URLS.social.telegram,
+    icon: TelegramLogoIcon,
   },
   {
     title: 'Report a FOC problem',
@@ -64,7 +72,7 @@ export default function Support() {
         <PageHeader
           centered
           title="Support"
-          description="Find the right channel for Filecoin Onchain Cloud help, problem reports, service status, and product feedback."
+          description="Find the right channel for Filecoin Onchain Cloud help, community discussion, problem reports, service status, and product feedback."
         />
       </PageSection>
 

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,102 @@
+import { CardGrid } from '@filecoin-foundation/ui-filecoin/CardGrid'
+import { Container } from '@filecoin-foundation/ui-filecoin/Container'
+import { LinkCard } from '@filecoin-foundation/ui-filecoin/LinkCard'
+import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
+import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
+import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
+import {
+  ChatCircleIcon,
+  GithubLogoIcon,
+  LightbulbIcon,
+  PulseIcon,
+} from '@phosphor-icons/react/dist/ssr'
+
+import { Navigation } from '@/components/Navigation/Navigation'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import { FOC_URLS } from '@/constants/site-metadata'
+import { createMetadata } from '@/utils/create-metadata'
+
+import { SUPPORT_SEO } from './constants/seo'
+import { generateStructuredData } from './utils/generate-structured-data'
+
+const supportOptions = [
+  {
+    title: 'Quick troubleshooting',
+    description:
+      'Use #fil-foc on Filecoin Slack when you are stuck and need fast back-and-forth with the team or other builders.',
+    href: FOC_URLS.social.slack,
+    icon: ChatCircleIcon,
+  },
+  {
+    title: 'Report a FOC problem',
+    description:
+      'Use the public GitHub intake form for reproducible bugs or persistent issues so context stays searchable and triageable.',
+    href: FOC_URLS.filecoinCloud.problemReports,
+    icon: GithubLogoIcon,
+  },
+  {
+    title: 'Check service status',
+    description:
+      'Use the status page for outages, active incidents, and high-level service availability updates.',
+    href: FOC_URLS.status,
+    icon: PulseIcon,
+  },
+  {
+    title: 'Share your use case',
+    description:
+      'Use the contact form for product feedback, partnerships, and ideas about what you want to build with Filecoin Onchain Cloud.',
+    href: PATHS.CONTACT.path,
+    icon: LightbulbIcon,
+  },
+] as const
+
+export default function Support() {
+  return (
+    <>
+      <StructuredDataScript
+        structuredData={generateStructuredData(SUPPORT_SEO)}
+      />
+
+      <Navigation backgroundVariant="light" />
+      <PageSection backgroundVariant="light">
+        <PageHeader
+          centered
+          title="Support"
+          description="Find the right channel for Filecoin Onchain Cloud help, problem reports, service status, and product feedback."
+        />
+      </PageSection>
+
+      <PageSection backgroundVariant="light" paddingVariant="topNone">
+        <Container>
+          <SectionContent
+            headingTag="h2"
+            title="Choose the best path"
+            description="Different requests need different channels. Start here so the team can respond in the place that fits the work."
+          >
+            <CardGrid as="ul" variant="mdTwo">
+              {supportOptions.map(({ title, description, href, icon }) => (
+                <LinkCard
+                  key={title}
+                  as="li"
+                  title={title}
+                  headingTag="h3"
+                  description={description}
+                  href={href}
+                  icon={{ component: icon, variant: 'filled' }}
+                />
+              ))}
+            </CardGrid>
+          </SectionContent>
+        </Container>
+      </PageSection>
+    </>
+  )
+}
+
+export const metadata = createMetadata({
+  title: SUPPORT_SEO.title,
+  description: SUPPORT_SEO.description,
+  path: PATHS.SUPPORT.path,
+})

--- a/src/app/support/utils/generate-structured-data.ts
+++ b/src/app/support/utils/generate-structured-data.ts
@@ -1,0 +1,16 @@
+import type { WebPageGraph } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import type { StructuredDataParams } from '@/types/structured-data-params'
+import { generatePageStructuredData } from '@/utils/generate-page-structured-data'
+
+export function generateStructuredData(
+  seo: StructuredDataParams,
+): WebPageGraph {
+  return generatePageStructuredData({
+    title: seo.title,
+    description: seo.description,
+    path: PATHS.SUPPORT.path,
+    pageType: 'WebPage',
+  })
+}

--- a/src/components/Navigation/constants/navigation.ts
+++ b/src/components/Navigation/constants/navigation.ts
@@ -26,6 +26,11 @@ export const headerNavigationItems: Array<NavItem | NavigationMenuItem> = [
             label: PATHS.AGENTS.label,
             href: PATHS.AGENTS.path,
           },
+          {
+            description: 'Find the right support channel for FOC',
+            label: PATHS.SUPPORT.label,
+            href: PATHS.SUPPORT.path,
+          },
         ],
       },
     ],
@@ -72,6 +77,10 @@ export const mobileNavigationItems: Array<NavItem> = [
   {
     label: 'Status',
     href: FOC_URLS.status,
+  },
+  {
+    label: PATHS.SUPPORT.label,
+    href: PATHS.SUPPORT.path,
   },
   {
     label: PATHS.CONTACT.label,

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -26,6 +26,10 @@ export const PATHS = {
     path: '/service-providers',
     label: 'Service Providers',
   },
+  SUPPORT: {
+    path: '/support',
+    label: 'Support',
+  },
   TERMS_OF_USE: {
     path: '/terms-of-use',
     label: 'Terms of Use',


### PR DESCRIPTION
## Summary
- Adds a draft /support page that collects FOC support paths in one place
- Links to #fil-foc for quick troubleshooting, FilOzone/foc-problems for persistent reports, the status page for incidents, and /contact for use cases/product feedback
- Adds Support to the Resources menu on desktop and mobile navigation for discoverability

## Stacking
This is stacked on top of #311 / phi/multi-channel-support so the current PR can stay focused on adding guidance to /contact.

## Verification
- npm run lint
- npm run build
- Verified /support locally via production server on port 3003