### PR TITLE
fix(ci): use pull_request_target for add-to-project workflow

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -15,7 +15,11 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
+  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # This action does not check out nor execute user code so we should be safe.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
+  pull_request_target:
     types:
       - opened
 
@@ -23,7 +27,6 @@ jobs:
   add-to-project:
     name: Add all issues and prs to project
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:


### PR DESCRIPTION
## Summary

- Switches the "Add issues and PRs to FS project board" workflow from `pull_request` to `pull_request_target`, matching [dealbot](https://github.com/FilOzone/dealbot/blob/main/.github/workflows/add-issues-and-prs-to-fs-project-board.yml) and the [github-mgmt template](https://github.com/FilOzone/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml).
- Fixes false CI failures where `FILOZZY_CI_ADD_TO_PROJECT` was empty for Dependabot and fork PRs (`Input required and not supplied: github-token`).
- Removes empty `permissions: {}` (not present in the canonical template).

The job only runs `actions/add-to-project@v1.0.2` and does not check out or execute PR code, which is the intended safe use of `pull_request_target`.

## Test plan

- [ ] Open a new PR (or re-run workflow on an existing Dependabot PR) and confirm "Add all issues and prs to project" succeeds
- [ ] Confirm fork PRs also get a green check (secret available via base-repo context)


Made with [Cursor](https://cursor.com)