### PR TITLE
feat(providers): determine reachability via /pdp/ping instead of version string

### DIFF
--- a/src/app/service-providers/components/ServiceProvidersTable.tsx
+++ b/src/app/service-providers/components/ServiceProvidersTable.tsx
@@ -61,6 +61,8 @@ export function ServiceProvidersTable({ data }: ServiceProvidersTableProps) {
     data,
     columns,
     enableMultiSort: false,
+    // Hide the filter-only `reachable` column (defined in column-definition).
+    initialState: { columnVisibility: { reachable: false } },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/src/app/service-providers/data/column-definition.tsx
+++ b/src/app/service-providers/data/column-definition.tsx
@@ -55,7 +55,6 @@ export const columns = [
     },
     sortingFn: sortSoftwareVersion,
     sortUndefined: 'last',
-    filterFn: reachableFilterFn,
   }),
   columnHelper.accessor('isActive', {
     id: 'serviceOffered',
@@ -121,5 +120,15 @@ export const columns = [
     },
     sortingFn: 'alphanumeric',
     sortUndefined: 'last',
+  }),
+  // Data-only column that backs the "reachable" filter (from the /pdp/ping probe).
+  // Kept hidden via columnVisibility in ServiceProvidersTable — it never renders,
+  // it just gives the filter its own column id instead of piggybacking on Version.
+  columnHelper.accessor('reachable', {
+    id: 'reachable',
+    header: 'Reachable',
+    enableSorting: false,
+    enableGlobalFilter: false,
+    filterFn: reachableFilterFn,
   }),
 ]

--- a/src/app/service-providers/utils/map-filter-state-to-column-filters.ts
+++ b/src/app/service-providers/utils/map-filter-state-to-column-filters.ts
@@ -51,7 +51,7 @@ export function mapFilterStateToColumnFilters({
     columnFilters.push({ id: 'serviceOffered', value: serviceTier })
   }
   if (reachable.length > 0) {
-    columnFilters.push({ id: 'softwareVersion', value: reachable })
+    columnFilters.push({ id: 'reachable', value: reachable })
   }
 
   return columnFilters

--- a/src/app/service-providers/utils/service-provider-filters.ts
+++ b/src/app/service-providers/utils/service-provider-filters.ts
@@ -40,12 +40,9 @@ export const reachableFilterFn: FilterFn<ServiceProvider> = (
   const reachableArray = filterValue as FilterState['reachable']
   if (reachableArray.length === 0) return true
 
-  // Reachability proxy: Curio only populates softwareVersion when the node is reachable.
-  // Treat any defined value (including empty string) as reachable.
-  const hasSoftwareVersion =
-    row.original.softwareVersion !== null &&
-    row.original.softwareVersion !== undefined
-  const reachableValue: FilterState['reachable'][number] = hasSoftwareVersion
+  // Reachability is determined by a live /pdp/ping probe (see services/providers/ping.ts).
+  const reachableValue: FilterState['reachable'][number] = row.original
+    .reachable
     ? 'true'
     : 'false'
   return reachableArray.includes(reachableValue)

--- a/src/schemas/provider-schema.ts
+++ b/src/schemas/provider-schema.ts
@@ -27,6 +27,7 @@ export const providerSchema = z.object({
   peerId: z.string().optional(),
   pricingPerTb: z.bigint(),
   providerId: z.number(),
+  reachable: z.boolean(),
   serviceProviderAddress: ethereumAddressSchema,
   serviceStatus: z.string().optional(),
   serviceUrl: z.url(),

--- a/src/services/providers/constants.ts
+++ b/src/services/providers/constants.ts
@@ -5,7 +5,8 @@
 export const BATCH_SIZE = 100
 export const PROVIDER_FETCH_LIMIT = 100
 export const VERSION_FETCH_TIMEOUT = 5_000
-export const VERSION_FETCH_CONCURRENCY = 20
+export const PING_FETCH_TIMEOUT = 5_000
+export const ENRICH_CONCURRENCY = 20
 export const PDP_PRODUCT_TYPE = 0
 
 export const VERSION_PATTERN =

--- a/src/services/providers/index.ts
+++ b/src/services/providers/index.ts
@@ -15,13 +15,14 @@ import { providerSchema, type ServiceProvider } from '@/schemas/provider-schema'
 import type { FetchProvidersOptions, ProviderFilter } from '@/types/providers'
 import { getCheckActivityUrl } from '@/utils/provider-urls'
 
-import { VERSION_FETCH_CONCURRENCY } from './constants'
+import { ENRICH_CONCURRENCY } from './constants'
 import {
   fetchApprovedProviderIds,
   fetchEndorsedProviderIds,
   fetchProviderById,
   fetchProvidersBulk,
 } from './contract'
+import { fetchReachable } from './ping'
 import type { BaseProviderData } from './types'
 import { fetchSoftwareVersion } from './version'
 
@@ -97,7 +98,7 @@ async function fetchProvidersByFilter(
 }
 
 /**
- * Enrich providers with additional information (software version and check activity URL)
+ * Enrich providers with additional information (software version, reachability, and check activity URL)
  */
 async function enrichProviders(
   providers: BaseProviderData[],
@@ -105,17 +106,20 @@ async function enrichProviders(
 ): Promise<ServiceProvider[]> {
   const providersWithVersions: ServiceProvider[] = []
 
-  // Process providers in batches
-  for (let i = 0; i < providers.length; i += VERSION_FETCH_CONCURRENCY) {
-    const batch = providers.slice(i, i + VERSION_FETCH_CONCURRENCY)
+  // Process providers in batches of ENRICH_CONCURRENCY (each fires /version + /pdp/ping)
+  for (let i = 0; i < providers.length; i += ENRICH_CONCURRENCY) {
+    const batch = providers.slice(i, i + ENRICH_CONCURRENCY)
     const batchResults = await Promise.all(
       batch.map(async (provider) => {
-        const softwareVersion = await fetchSoftwareVersion(provider.serviceUrl)
+        const [softwareVersion, reachable] = await Promise.all([
+          fetchSoftwareVersion(provider.serviceUrl),
+          fetchReachable(provider.serviceUrl),
+        ])
         const checkActivityUrl = getCheckActivityUrl(
           network,
           provider.payeeAddress,
         )
-        return { ...provider, softwareVersion, checkActivityUrl }
+        return { ...provider, softwareVersion, reachable, checkActivityUrl }
       }),
     )
     providersWithVersions.push(...batchResults)

--- a/src/services/providers/index.ts
+++ b/src/services/providers/index.ts
@@ -104,7 +104,7 @@ async function enrichProviders(
   providers: BaseProviderData[],
   network: Network,
 ): Promise<ServiceProvider[]> {
-  const providersWithVersions: ServiceProvider[] = []
+  const enrichedProviders: ServiceProvider[] = []
 
   // Process providers in batches of ENRICH_CONCURRENCY (each fires /version + /pdp/ping)
   for (let i = 0; i < providers.length; i += ENRICH_CONCURRENCY) {
@@ -122,11 +122,11 @@ async function enrichProviders(
         return { ...provider, softwareVersion, reachable, checkActivityUrl }
       }),
     )
-    providersWithVersions.push(...batchResults)
+    enrichedProviders.push(...batchResults)
   }
 
   const valid: ServiceProvider[] = []
-  for (const provider of providersWithVersions) {
+  for (const provider of enrichedProviders) {
     const result = providerSchema.safeParse(provider)
     if (result.success) {
       valid.push(result.data)

--- a/src/services/providers/ping.ts
+++ b/src/services/providers/ping.ts
@@ -1,0 +1,42 @@
+import { PING_FETCH_TIMEOUT } from './constants'
+
+/**
+ * Ping a provider's /pdp/ping endpoint to determine reachability.
+ * Success is determined purely by HTTP status (2xx), the body is ignored.
+ * Safe to call from the browser: Curio serves /pdp/ping over HTTPS with
+ * permissive CORS headers.
+ */
+async function pingProvider(serviceUrl: string): Promise<boolean> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), PING_FETCH_TIMEOUT)
+
+  try {
+    const baseUrl = serviceUrl.replace(/\/$/, '')
+
+    const response = await fetch(`${baseUrl}/pdp/ping`, {
+      method: 'GET',
+      mode: 'cors',
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeoutId)
+
+    return response.ok
+  } catch {
+    clearTimeout(timeoutId)
+    return false
+  }
+}
+
+/**
+ * Determine whether a provider is reachable via its /pdp/ping endpoint.
+ * @param serviceUrl - Provider service URL
+ * @returns true if the node responds with a 2xx status, false otherwise
+ */
+export async function fetchReachable(serviceUrl?: string): Promise<boolean> {
+  if (!serviceUrl) {
+    return false
+  }
+
+  return pingProvider(serviceUrl)
+}

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -1,9 +1,9 @@
 import type { ServiceProvider } from '@/schemas/provider-schema'
 
 /**
- * Base provider data from contract (before enrichment with software version and check activity URL)
+ * Base provider data from contract (before enrichment with software version, reachability, and check activity URL)
  */
 export type BaseProviderData = Omit<
   ServiceProvider,
-  'softwareVersion' | 'checkActivityUrl'
+  'softwareVersion' | 'checkActivityUrl' | 'reachable'
 >


### PR DESCRIPTION
## What
Replace the version-string reachability proxy with a real `/pdp/ping` probe.

## Why
The Service Providers table defaults to showing only reachable providers (`reachable=['true']`). Reachability was *inferred* from whether a provider's `/version` string parsed into a known format. That conflated "has a parseable version" with "is reachable" — providers running prerelease Curio builds (version like `1.28.2-rc1+...`) failed the version pattern and were therefore treated as unreachable and dropped from the default list.

## How
- Add `fetchReachable()` hitting `GET /pdp/ping`; `2xx` ⇒ reachable. The endpoint serves permissive CORS (`access-control-allow-origin: *`), so the existing browser-side enrichment can call it directly.
- Add a `reachable` boolean to `ServiceProvider`, populated during enrichment (runs concurrently with the `/version` fetch).
- `reachableFilterFn` now reads `reachable` directly instead of the `softwareVersion` proxy.

Part of #319. The Version-column display of prerelease builds is fixed separately, pending upstream FilecoinFoundationWeb/filecoin-foundation#2336.

## Test
- `GET https://pdp.660688.xyz:8443/pdp/ping` → `200`, `access-control-allow-origin: *`.
- `biome check` + `tsc` clean on changed files.
