### PR TITLE
fix(providers): parse prerelease Curio versions (e.g. 1.28.2-rc1)

### DIFF
--- a/src/services/providers/constants.ts
+++ b/src/services/providers/constants.ts
@@ -7,6 +7,3 @@ export const PROVIDER_FETCH_LIMIT = 100
 export const VERSION_FETCH_TIMEOUT = 5_000
 export const VERSION_FETCH_CONCURRENCY = 20
 export const PDP_PRODUCT_TYPE = 0
-
-export const VERSION_PATTERN =
-  /^\d+\.\d+\.\d+\+\w+\+git_[a-f0-9]+_\d{4}-\d{2}-\d{2}T[\d:+-]+$/

--- a/src/services/providers/version.ts
+++ b/src/services/providers/version.ts
@@ -1,4 +1,6 @@
-import { VERSION_FETCH_TIMEOUT, VERSION_PATTERN } from './constants'
+import { parseVersionString } from '@filecoin-foundation/ui-filecoin/Table/SoftwareVersion'
+
+import { VERSION_FETCH_TIMEOUT } from './constants'
 
 /**
  * Parse version from response text
@@ -19,10 +21,10 @@ function parseVersionFromResponse(responseText: string): string {
 }
 
 /**
- * Validate version string format
+ * Validate a version string using the same parser as the table display and CSV.
  */
 function isValidVersion(version: string): boolean {
-  return VERSION_PATTERN.test(version)
+  return parseVersionString(version) !== undefined
 }
 
 /**


### PR DESCRIPTION
> **Draft** — gated on the upstream parser fix. The code change here is complete; the only remaining step is bumping `@filecoin-foundation/ui-filecoin` to the release that ships the prerelease-aware parser (FilecoinFoundationWeb/filecoin-foundation#2337) and updating the lockfile. **Do not merge before that bump** — until then the package still rejects `-rc1`.

## What
Validate software versions with `@filecoin-foundation/ui-filecoin`'s `parseVersionString` instead of a duplicate local regex, so prerelease Curio builds (e.g. `1.28.2-rc1`) are handled consistently everywhere.

## Why
`isValidVersion` used a local `VERSION_PATTERN` that, like the package's `parseVersionString`, rejected the `-rc1` prerelease suffix. RC builds failed validation, so `softwareVersion` was left unset and the Version column showed `-`. The display component and CSV export already use the package parser, so the local regex was a second, divergent copy of the same logic.

## How
- `isValidVersion` now returns `parseVersionString(version) !== undefined` — a single source of truth shared with display and CSV.
- Remove the duplicate `VERSION_PATTERN`.

No local parser and no custom render: prerelease support arrives entirely through the dependency once #2337 is released.

### Remaining step (on upstream release)
- Bump `@filecoin-foundation/ui-filecoin` to the fixed release + commit the lockfile, then mark ready.

Part of #319. Upstream fix: FilecoinFoundationWeb/filecoin-foundation#2336 / #2337.
