### PR TITLE
fix(providers): parse prerelease Curio versions locally (e.g. 1.28.2-rc1)

### DIFF
--- a/src/app/service-providers/utils/map-provider-to-csv-row.ts
+++ b/src/app/service-providers/utils/map-provider-to-csv-row.ts
@@ -1,14 +1,13 @@
-import { parseVersionString } from '@filecoin-foundation/ui-filecoin/Table/SoftwareVersion'
-
 import { CURIO_GITHUB_URL } from '@/constants/github-urls'
 import type { ServiceProvider } from '@/schemas/provider-schema'
+import { parseSoftwareVersion } from '@/utils/parse-software-version'
 
 export type MapProviderToCsvRowProps = {
   provider: ServiceProvider
 }
 
 export function mapProviderToCsvRow({ provider }: MapProviderToCsvRowProps) {
-  const versionInfo = parseVersionString(provider.softwareVersion || '')
+  const versionInfo = parseSoftwareVersion(provider.softwareVersion || '')
 
   const EMPTY_VALUE = ''
 

--- a/src/components/SoftwareVersion.tsx
+++ b/src/components/SoftwareVersion.tsx
@@ -1,11 +1,41 @@
-import { SoftwareVersion as SharedSoftwareVersion } from '@filecoin-foundation/ui-filecoin/Table/SoftwareVersion'
+import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
+import { formatDateTime } from '@filecoin-foundation/ui-filecoin/utils'
 
 import { CURIO_GITHUB_URL } from '@/constants/github-urls'
+import { parseSoftwareVersion } from '@/utils/parse-software-version'
 
 type SoftwareVersionProps = {
   info: string
 }
 
+/**
+ * Renders a parsed Curio version string. This mirrors the markup of
+ * `@filecoin-foundation/ui-filecoin`'s `SoftwareVersion`, but uses the local
+ * prerelease-aware parser so builds like `1.28.2-rc1` display correctly until
+ * the upstream parser fix ships (see `@/utils/parse-software-version`).
+ */
 export function SoftwareVersion({ info }: SoftwareVersionProps) {
-  return <SharedSoftwareVersion githubUrl={CURIO_GITHUB_URL} info={info} />
+  const match = parseSoftwareVersion(info)
+
+  if (!match) {
+    return <p>The software version could not be parsed.</p>
+  }
+
+  const { version, network, commit, date } = match
+  const formattedDate = date ? formatDateTime(date) : null
+
+  return (
+    <div className="space-y-0.5 text-sm text-gray-600">
+      {version && network && <p>{`${version} (${network})`}</p>}
+      {commit && (
+        <p>
+          commit{' '}
+          <ExternalTextLink href={`${CURIO_GITHUB_URL}${commit}`}>
+            {commit}
+          </ExternalTextLink>
+        </p>
+      )}
+      {formattedDate && <p>{formattedDate}</p>}
+    </div>
+  )
 }

--- a/src/services/providers/constants.ts
+++ b/src/services/providers/constants.ts
@@ -8,6 +8,3 @@ export const VERSION_FETCH_TIMEOUT = 5_000
 export const PING_FETCH_TIMEOUT = 5_000
 export const ENRICH_CONCURRENCY = 20
 export const PDP_PRODUCT_TYPE = 0
-
-export const VERSION_PATTERN =
-  /^\d+\.\d+\.\d+\+\w+\+git_[a-f0-9]+_\d{4}-\d{2}-\d{2}T[\d:+-]+$/

--- a/src/services/providers/version.ts
+++ b/src/services/providers/version.ts
@@ -1,4 +1,6 @@
-import { VERSION_FETCH_TIMEOUT, VERSION_PATTERN } from './constants'
+import { parseSoftwareVersion } from '@/utils/parse-software-version'
+
+import { VERSION_FETCH_TIMEOUT } from './constants'
 
 /**
  * Parse version from response text
@@ -19,10 +21,10 @@ function parseVersionFromResponse(responseText: string): string {
 }
 
 /**
- * Validate version string format
+ * Validate a version string using the same parser as the table display and CSV.
  */
 function isValidVersion(version: string): boolean {
-  return VERSION_PATTERN.test(version)
+  return parseSoftwareVersion(version) !== undefined
 }
 
 /**

--- a/src/utils/parse-software-version.ts
+++ b/src/utils/parse-software-version.ts
@@ -1,0 +1,37 @@
+/**
+ * Local fork of `parseVersionString` from
+ * `@filecoin-foundation/ui-filecoin/Table/SoftwareVersion`.
+ *
+ * Identical output shape to the upstream parser, but the semver core also
+ * accepts an optional prerelease suffix (e.g. `-rc1`, `-beta.1`) so prerelease
+ * Curio builds are parsed instead of rejected. The upstream regex hard-codes
+ * `\d+\.\d+\.\d+` with no prerelease segment.
+ *
+ * Revert to the package parser once the upstream fix ships:
+ * https://github.com/FilecoinFoundationWeb/filecoin-foundation/issues/2336
+ */
+
+export type ParsedSoftwareVersion = {
+  version: string
+  network: string
+  commit: string
+  date: string
+}
+
+// Same as upstream, with an optional `-<prerelease>` segment after the patch number.
+const VERSION_REGEX =
+  /^(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\+([a-z]+)\+(git_[a-f0-9]+)_(.+)$/
+
+export function parseSoftwareVersion(
+  input: string,
+): ParsedSoftwareVersion | undefined {
+  const match = input.match(VERSION_REGEX)
+  if (!match) return undefined
+
+  return {
+    version: match[1],
+    network: match[2],
+    commit: match[3].replace('git_', ''),
+    date: match[4],
+  }
+}


### PR DESCRIPTION
## What
Handle prerelease Curio version strings (e.g. `1.28.2-rc1+calibnet+git_...`) entirely **locally**, so they pass validation, render correctly in the Version column, and export to CSV — without waiting on an upstream `@filecoin-foundation/ui-filecoin` release.

## Why
Three independent code paths rejected the `-rc1` / `-beta` prerelease suffix:
- **Validation** — `isValidVersion` used a local `VERSION_PATTERN` whose `\d+\.\d+\.\d+` core had no prerelease segment ⇒ `softwareVersion` left unset ⇒ Version column showed `-`.
- **Display** — the package's `parseVersionString` (used by `SoftwareVersion`) had the same gap ⇒ "The software version could not be parsed."
- **CSV** — `mapProviderToCsvRow` also used the package parser ⇒ empty Version/Network/Commit fields.

This supersedes #321, which only swapped local validation onto the package parser and therefore stayed blocked on the upstream parser fix (FilecoinFoundationWeb/filecoin-foundation#2336) shipping in a release. Since that release keeps slipping, this PR removes the upstream dependency for the parse logic.

> Note: reachability is no longer proxied by the version string — #320 already replaced that with a real `/pdp/ping` probe — so prerelease nodes are no longer filtered out of the default view. This PR only fixes the remaining parse/display/CSV gap.

## How
- Add `src/utils/parse-software-version.ts` — a single local parser with the **same output shape** as the upstream `parseVersionString`, plus an optional `-<prerelease>` segment in the semver core.
- Route all three consumers through it: `isValidVersion` (validation), the Version cell, and the CSV export.
- Render the Version cell locally (reusing the package's `ExternalTextLink` and `formatDateTime`), because the upstream `SoftwareVersion` component parses internally and can't be given a different parser. Markup/classNames mirror upstream for visual parity.
- Remove the now-unused `VERSION_PATTERN`.

## Revert path
Once the upstream parser fix ships, revert to `parseVersionString` from the package and delete the local parser (a pointer to FilecoinFoundationWeb/filecoin-foundation#2336 is left in the file header).

## Testing
- Parser checked against stable (`1.28.2`), `1.28.2-rc1`, and `1.28.2-beta.1` strings — all parse to correct version/network/commit/date; junk and empty strings return `undefined`.
- `biome check` and `tsc --noEmit` clean for the changed files.
- Verified locally against a prerelease node: Version column renders `1.28.2-rc1 (calibnet)` with commit link + build date; no column overflow from the suffix.

Part of #319. Supersedes #321.