### PR TITLE
fix: update status page link

### DIFF
--- a/src/constants/site-metadata.ts
+++ b/src/constants/site-metadata.ts
@@ -41,7 +41,7 @@ const FOC_URLS = {
     repository: 'https://github.com/FilOzone/filecoin-cloud',
   },
   filecoinPay: 'https://pay.filecoin.cloud/mainnet',
-  status: 'https://status.filoz.org',
+  status: 'https://status.filecoin.cloud',
   payments: {
     contractSourceCode:
       'https://github.com/FilOzone/filecoin-pay/tree/main/src',


### PR DESCRIPTION
## Summary
- Update the shared Filecoin Cloud status page URL to https://status.filecoin.cloud.
- Ensure banner/navigation status links resolve to the Filecoin Cloud status domain.

## Validation
- npm run lint