### PR TITLE
fix(providers): decode capacityTib from ASCII string instead of raw hex

### DIFF
--- a/src/utils/decode-pdp-capabilities.ts
+++ b/src/utils/decode-pdp-capabilities.ts
@@ -73,13 +73,12 @@ function decodeCapacity(capacityHex?: Hex): bigint | undefined {
 
   try {
     // First decode the hex to string to check if it's a text value
-    const decodedValue = hexToString(capacityHex)
+    const decodedValue = hexToString(capacityHex).trim()
     // If it's a non-numeric string (like "enter available storage"), return undefined
-    if (Number.isNaN(Number(decodedValue))) {
+    if (decodedValue === '' || Number.isNaN(Number(decodedValue))) {
       return undefined
     }
-    // Otherwise, convert the original hex to BigInt
-    return BigInt(capacityHex)
+    return BigInt(decodedValue)
   } catch {
     return undefined
   }


### PR DESCRIPTION
`capacityTib` is stored on-chain as an ASCII string (e.g. "12"), but `decodeCapacity` was returning `BigInt(capacityHex)` — converting the raw hex bytes to a number instead of the decoded value.

A provider reporting 12 TiB (`0x3132`) was displayed as 12,594.

Fix: return `BigInt(decodedValue)` using the decoded string.