### PR TITLE
feat(contact): track successful submissions as a Plausible event

### DIFF
--- a/src/app/contact/components/ContactForm.tsx
+++ b/src/app/contact/components/ContactForm.tsx
@@ -5,7 +5,8 @@ import { Checkbox } from '@filecoin-foundation/ui-filecoin/Checkbox'
 import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
 import { Field, Label } from '@headlessui/react'
 import Script from 'next/script'
-import { useActionState, useState } from 'react'
+import { usePlausible } from 'next-plausible'
+import { useActionState, useEffect, useState } from 'react'
 
 import { PATHS } from '@/constants/paths'
 
@@ -26,6 +27,13 @@ export function ContactForm() {
     INITIAL_STATE,
   )
   const [optIn, setOptIn] = useState(false)
+  const plausible = usePlausible()
+
+  useEffect(() => {
+    if (state.status === 'success') {
+      plausible('Contact Form Submit')
+    }
+  }, [state.status, plausible])
 
   if (state.status === 'success') {
     return (


### PR DESCRIPTION
## 📝 Description

Adds Plausible analytics tracking for successful contact-form submissions, so we can measure the conversion rate from `/contact` page visits to actual submissions week over week (via Plausible Goals and Funnels).

- **Type:** Feature

## 🛠️ Key Changes

- Fire a `Contact Form Submit` Plausible event from `ContactForm` when the form action state transitions to `success`.
- Use the `usePlausible()` hook from `next-plausible` (already configured in `Providers`) rather than a raw `window.plausible(...)` call, keeping it consistent with the existing setup and type-safe/script-load-safe.
- The event is fired from a `useEffect` keyed on `state.status`, because submission runs through a React 19 Server Action and the success state only surfaces client-side — so it fires exactly once when the "Message sent" panel renders.

## 📌 To-Do Before Merging

- [ ] Create the `Contact Form Submit` **Goal** in the Plausible dashboard (and optionally a `/contact` → goal Funnel) — the code change alone won't register the goal.
