### PR TITLE
fix(ci): accept upstream contract metadata

### DIFF
--- a/src/schemas/deployments-schema.ts
+++ b/src/schemas/deployments-schema.ts
@@ -9,13 +9,29 @@ const ethereumAddressSchema = z
   )
   .transform((value) => getAddress(value) as Address)
 
+const deploymentContractSchema = z
+  .object({
+    initcode_hash: z.string().optional(),
+    artifact_contract: z.string().optional(),
+    libraries: z.record(z.string(), ethereumAddressSchema).optional(),
+    constructor_args: z.array(z.string()).optional(),
+    pinned: z.boolean().optional(),
+  })
+  .passthrough()
+
+const deploymentsMetadataSchema = z
+  .object({
+    note: z.string().optional(),
+    commit: z.string().optional(),
+    deployed_at: z.string().optional(),
+    fwss_version: z.string().optional(),
+    pdp_version: z.string().optional(),
+  })
+  .passthrough()
+
 const chainDeploymentsSchema = z
   .object({
-    metadata: z
-      .object({
-        note: z.string().optional(),
-      })
-      .optional(),
+    metadata: deploymentsMetadataSchema.optional(),
     FILECOIN_PAY_ADDRESS: ethereumAddressSchema,
     PDP_VERIFIER_PROXY_ADDRESS: ethereumAddressSchema,
     PDP_VERIFIER_IMPLEMENTATION_ADDRESS: ethereumAddressSchema,
@@ -27,6 +43,7 @@ const chainDeploymentsSchema = z
     FWSS_IMPLEMENTATION_ADDRESS: ethereumAddressSchema,
     FWSS_VIEW_ADDRESS: ethereumAddressSchema,
     ENDORSEMENT_SET_ADDRESS: ethereumAddressSchema,
+    contracts: z.record(z.string(), deploymentContractSchema).optional(),
   })
   .catchall(ethereumAddressSchema)
 


### PR DESCRIPTION
## Summary

- Allow `deployments.json` entries to include upstream `contracts` deployment metadata objects.
- Preserve richer upstream `metadata` fields while keeping required address fields validated as Ethereum addresses.

## Root Cause

The scheduled Sync Contract Addresses workflow failed because upstream `service_contracts/deployments.json` now includes a top-level `contracts` object under chain IDs `314` and `314159`. The local schema treated unknown fields as address strings, so validation failed before the workflow could compare addresses or open its automated sync PR.

This is due to the change in https://github.com/FilOzone/filecoin-services/pull/530