### PR TITLE
feat(showcase): add FOC demos and agent resources page

### DIFF
--- a/src/app/showcase/constants/seo.ts
+++ b/src/app/showcase/constants/seo.ts
@@ -1,0 +1,5 @@
+export const SHOWCASE_SEO = {
+  title: 'Showcase | Filecoin Onchain Cloud',
+  description:
+    'Explore demos, reference apps, SDKs, and agent tools built on Filecoin Onchain Cloud. Fork a starter, give your AI agents storage, or get inspired by what the community is shipping.',
+} as const

--- a/src/app/showcase/data/agent-resources.ts
+++ b/src/app/showcase/data/agent-resources.ts
@@ -30,12 +30,12 @@ export const agentResources = [
     },
   },
   {
-    title: 'FOC Storage Skill',
+    title: 'FOC Agent Skills',
     description:
-      'An installable agent skill that wraps the FOC Storage MCP server for Clawdbot, so an agent can run Filecoin storage operations out of the box.',
-    badge: { text: 'Agent skill', variant: 'solid' },
+      'Two installable skills that ship with the FOC CLI. One runs storage and payment operations such as uploads, datasets, and USDFC funding; the other searches the FOC docs so agents can look up references before they build.',
+    badge: { text: 'Agent skills', variant: 'solid' },
     source: {
-      href: 'https://github.com/FIL-Builders/foc-storage-clawdbot-skill',
+      href: 'https://github.com/FIL-Builders/foc-cli/tree/main/skills',
       label: 'View code',
     },
   },

--- a/src/app/showcase/data/agent-resources.ts
+++ b/src/app/showcase/data/agent-resources.ts
@@ -1,0 +1,42 @@
+import type { ShowcaseCardData } from '@/components/ShowcaseCard'
+
+export const agentResources = [
+  {
+    title: 'FOC CLI',
+    description:
+      'Stores files on Filecoin Onchain Cloud from the terminal or inside an agent. It manages wallets, USDFC funding, datasets, and uploads on the Synapse SDK, and ships an MCP mode for agents.',
+    badge: { text: 'CLI', variant: 'solid' },
+    primary: {
+      href: 'https://www.npmjs.com/package/foc-cli',
+      label: 'View on npm',
+    },
+    source: {
+      href: 'https://github.com/FIL-Builders/foc-cli',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'FOC Storage MCP Server',
+    description:
+      'A Model Context Protocol server that gives AI assistants Filecoin storage. Agents upload files, manage datasets, deposit USDFC, and pick providers over MCP.',
+    badge: { text: 'MCP server', variant: 'solid' },
+    primary: {
+      href: 'https://www.npmjs.com/package/@fil-b/foc-storage-mcp',
+      label: 'View on npm',
+    },
+    source: {
+      href: 'https://github.com/FIL-Builders/foc-storage-mcp',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'FOC Storage Skill',
+    description:
+      'An installable agent skill that wraps the FOC Storage MCP server for Clawdbot, so an agent can run Filecoin storage operations out of the box.',
+    badge: { text: 'Agent skill', variant: 'solid' },
+    source: {
+      href: 'https://github.com/FIL-Builders/foc-storage-clawdbot-skill',
+      label: 'View code',
+    },
+  },
+] as const satisfies Array<ShowcaseCardData>

--- a/src/app/showcase/data/building-blocks.ts
+++ b/src/app/showcase/data/building-blocks.ts
@@ -1,0 +1,80 @@
+import type { ShowcaseCardData } from '@/components/ShowcaseCard'
+
+export const buildingBlocks = [
+  {
+    title: 'Synapse SDK',
+    description:
+      'The core JavaScript and TypeScript SDK for Filecoin Onchain Cloud, covering storage, USDFC payments, session keys, and retrieval across Node, browsers, and React.',
+    badge: { text: 'SDK', variant: 'primary' },
+    primary: {
+      href: 'https://docs.filecoin.cloud',
+      label: 'Read the docs',
+    },
+    source: {
+      href: 'https://github.com/FilOzone/synapse-sdk',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'FOC Upload dApp',
+    description:
+      'A production Next.js starter for FOC storage apps, with multi-file uploads, CDN and Filecoin Pin modes, USDFC management, and a live dashboard.',
+    badge: { text: 'Starter dApp', variant: 'primary' },
+    primary: {
+      href: 'https://foc-demo.filbuilders.eth.limo',
+      label: 'Try the demo',
+    },
+    source: {
+      href: 'https://github.com/FIL-Builders/foc-upload-dapp',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Filecoin Pin',
+    description:
+      'Decentralized IPFS pinning backed by Filecoin proofs. It pins content to the PDP service and ships as a CLI, a library, and a GitHub Action.',
+    badge: { text: 'IPFS pinning', variant: 'primary' },
+    primary: {
+      href: 'https://pin.filecoin.cloud/',
+      label: 'Open Filecoin Pin',
+    },
+    source: {
+      href: 'https://github.com/filecoin-project/filecoin-pin',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Synapse Playground',
+    description:
+      'An in-repo React and Vite example that exercises FOC storage, payments, and retrieval through the Synapse SDK.',
+    badge: { text: 'Example app', variant: 'primary' },
+    source: {
+      href: 'https://github.com/FilOzone/synapse-sdk/tree/master/apps/synapse-playground',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Synapse Go',
+    description:
+      'A community Go port of the Synapse SDK that brings FOC storage, payments, and retrieval to Go services.',
+    badge: { text: 'Go SDK', variant: 'primary' },
+    source: {
+      href: 'https://github.com/strahe/synapse-go',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Pynapse',
+    description:
+      'A Python port of the Synapse SDK that brings FOC storage, payments, and retrieval to Python apps and agents.',
+    badge: { text: 'Python SDK', variant: 'primary' },
+    primary: {
+      href: 'https://pypi.org/project/synapse-filecoin-sdk/',
+      label: 'View on PyPI',
+    },
+    source: {
+      href: 'https://github.com/anjor/pynapse',
+      label: 'View code',
+    },
+  },
+] as const satisfies Array<ShowcaseCardData>

--- a/src/app/showcase/data/community-demos.ts
+++ b/src/app/showcase/data/community-demos.ts
@@ -1,0 +1,138 @@
+import type { ShowcaseCardData } from '@/components/ShowcaseCard'
+
+export const communityDemos = [
+  {
+    title: 'Filosign',
+    description:
+      'A decentralized DocuSign alternative where signatures and verifications persist immutably on Filecoin, staying verifiable long after they are made.',
+    badge: { text: 'E-signatures', variant: 'primary' },
+    primary: {
+      href: 'https://app.filosign.xyz/',
+      label: 'Open the app',
+    },
+  },
+  {
+    title: 'W3Stor',
+    description:
+      'A storage and memory layer for AI agents. Files and memories get an IPFS CID, replicate across FOC providers with PDP attestation, and form a semantic graph for recall.',
+    badge: { text: 'Agent memory', variant: 'primary' },
+    primary: {
+      href: 'https://www.w3stor.xyz/',
+      label: 'Open W3Stor',
+    },
+    source: {
+      href: 'https://github.com/aikarap/w3stor',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Engram SDK',
+    description:
+      "A budget-aware memory SDK for AI agents. Every store writes content-addressed data to Filecoin through the Synapse SDK, paid from the agent's own wallet in USDFC.",
+    badge: { text: 'Memory SDK', variant: 'primary' },
+    primary: {
+      href: 'https://engramsdk.dev/',
+      label: 'Visit site',
+    },
+    source: {
+      href: 'https://github.com/aryza0x/engram-sdk',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Compose Mesh',
+    description:
+      'A desktop runtime where autonomous agents network over libp2p and anchor their state to Filecoin through the Synapse SDK. The Compose.Market marketplace lets users build and monetize agent swarms.',
+    badge: { text: 'Agent platform', variant: 'primary' },
+    primary: {
+      href: 'https://compose.market',
+      label: 'Open Compose',
+    },
+    source: {
+      href: 'https://github.com/compose-market/mesh',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Spawn Protocol',
+    description:
+      'An AI agent swarm that governs DAOs onchain. Parent agents spawn children to vote on proposals, storing execution logs and lineage on Filecoin through the Synapse SDK.',
+    badge: { text: 'DAO agents', variant: 'primary' },
+    primary: {
+      href: 'https://spawn-protocol-f1td.vercel.app/',
+      label: 'Open the app',
+    },
+    source: {
+      href: 'https://github.com/ishitab02/Spawn-Protocol',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'FilCraft',
+    description:
+      'An onchain marketplace where AI agents register identities, build reputation, and sell data, paid over x402. Session transcripts and outputs are stored on Filecoin through the Synapse SDK.',
+    badge: { text: 'Agent economy', variant: 'primary' },
+    primary: {
+      href: 'https://filcraft.vercel.app/',
+      label: 'Open the app',
+    },
+    source: {
+      href: 'https://github.com/sirdesai22/filcraft',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'EJENTS',
+    description:
+      'Autonomous agents run an onchain credit market of lending, tasks, and liquidations. Snapshots and reasoning traces are pinned with Filecoin Pin and recorded onchain.',
+    badge: { text: 'Credit markets', variant: 'primary' },
+    primary: {
+      href: 'https://ejents.vercel.app',
+      label: 'Open the app',
+    },
+    source: {
+      href: 'https://github.com/Leihyn/ejents',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Claw Vault',
+    description:
+      "A CLI that snapshots an AI agent's full state and backs it up to Filecoin Warm Storage with PDP-verified copies, restoring it byte for byte from a CID.",
+    badge: { text: 'Agent backup', variant: 'primary' },
+    source: {
+      href: 'https://github.com/Shriiii01/claw_vault',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Filify',
+    description:
+      'A deploy platform for the decentralized web. Connect a repo, build, publish to Filecoin through filecoin-pin, and point an ENS name at the resulting CID.',
+    badge: { text: 'Deploy platform', variant: 'primary' },
+    source: {
+      href: 'https://github.com/hrsh22/filify',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'dMail',
+    description:
+      'A serverless, encrypted email client addressed by ENS. Messages and attachments are stored on Filecoin through the Synapse SDK.',
+    badge: { text: 'Encrypted email', variant: 'primary' },
+    source: {
+      href: 'https://github.com/rohitshukla11/dmail',
+      label: 'View code',
+    },
+  },
+  {
+    title: 'Agentex',
+    description:
+      'A marketplace where AI trading agents buy and sell encrypted trade experiences. The reasoning is pinned to Filecoin with onchain proofs and settled with Filecoin Pay.',
+    badge: { text: 'Agent marketplace', variant: 'primary' },
+    source: {
+      href: 'https://github.com/casterkay/Agentex',
+      label: 'View code',
+    },
+  },
+] as const satisfies Array<ShowcaseCardData>

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -1,0 +1,148 @@
+import { Button } from '@filecoin-foundation/ui-filecoin/Button'
+import { CardGrid } from '@filecoin-foundation/ui-filecoin/CardGrid'
+import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
+import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
+import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
+
+import { Navigation } from '@/components/Navigation/Navigation'
+import { ShowcaseCard, type ShowcaseCardData } from '@/components/ShowcaseCard'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import { BASE_URL, FOC_URLS } from '@/constants/site-metadata'
+import { createMetadata } from '@/utils/create-metadata'
+
+import { SHOWCASE_SEO } from './constants/seo'
+import { agentResources } from './data/agent-resources'
+import { buildingBlocks } from './data/building-blocks'
+import { communityDemos } from './data/community-demos'
+import { generateStructuredData } from './utils/generate-structured-data'
+
+const ghostOnDark =
+  '!border-zinc-50/40 !bg-transparent hover:!border-zinc-50 hover:!bg-zinc-50/5'
+
+const allShowcaseItems: Array<ShowcaseCardData> = [
+  ...agentResources,
+  ...buildingBlocks,
+  ...communityDemos,
+]
+
+const showcaseItems = allShowcaseItems.map(
+  ({ title, description, primary, source }) => ({
+    title,
+    description,
+    url: (primary ?? source)?.href ?? `${BASE_URL}${PATHS.SHOWCASE.path}`,
+  }),
+)
+
+export default function Showcase() {
+  return (
+    <>
+      <StructuredDataScript
+        structuredData={generateStructuredData(SHOWCASE_SEO, showcaseItems)}
+      />
+
+      <Navigation backgroundVariant="dark" />
+
+      <PageSection backgroundVariant="dark">
+        <PageHeader
+          centered
+          variant="highContrast"
+          title="Built with Filecoin Onchain Cloud"
+          description="Explore the tools, SDKs, and apps the community is building on FOC. Fork a reference app, drop storage into your agent, or get inspired by what's already shipping."
+          cta={[
+            <Button
+              key="start-building"
+              href={FOC_URLS.documentation.gettingStarted}
+              variant="primary"
+            >
+              Start building
+            </Button>,
+            <Button
+              key="submit-project"
+              href={PATHS.CONTACT.path}
+              variant="ghost"
+              className={ghostOnDark}
+            >
+              Submit your project
+            </Button>,
+          ]}
+        />
+      </PageSection>
+
+      <PageSection backgroundVariant="gray">
+        <SectionContent
+          headingTag="h2"
+          title="Plug your agents into Filecoin"
+          description="Give AI agents Filecoin storage in minutes. A drop-in CLI, an MCP server, and an installable skill, all speaking the Synapse SDK."
+        >
+          <CardGrid as="ul" variant="smTwoLgThreeWider">
+            {agentResources.map((resource) => (
+              <ShowcaseCard key={resource.title} {...resource} />
+            ))}
+          </CardGrid>
+        </SectionContent>
+      </PageSection>
+
+      <PageSection backgroundVariant="light">
+        <SectionContent
+          headingTag="h2"
+          title="SDKs & reference apps"
+          description="Official building blocks and starter apps to fork, from the core SDK to a full-stack upload dApp."
+        >
+          <CardGrid as="ul" variant="smTwoLgThreeWider">
+            {buildingBlocks.map((block) => (
+              <ShowcaseCard key={block.title} {...block} />
+            ))}
+          </CardGrid>
+        </SectionContent>
+      </PageSection>
+
+      <PageSection backgroundVariant="gray">
+        <SectionContent
+          headingTag="h2"
+          title="Built by the community"
+          description="Real applications shipping on Filecoin Onchain Cloud. Explore what's possible, then build your own."
+        >
+          <CardGrid as="ul" variant="smTwoLgThreeWider">
+            {communityDemos.map((demo) => (
+              <ShowcaseCard key={demo.title} {...demo} />
+            ))}
+          </CardGrid>
+        </SectionContent>
+      </PageSection>
+
+      <PageSection backgroundVariant="dark">
+        <PageHeader
+          centered
+          variant="highContrast"
+          title="Building on Filecoin Onchain Cloud?"
+          description="Ship a working app on FOC and we'll feature it here. Tell us what you're building."
+          cta={[
+            <Button
+              key="submit-project"
+              href={PATHS.CONTACT.path}
+              variant="primary"
+            >
+              Submit your project
+            </Button>,
+            <Button
+              key="read-docs"
+              href={FOC_URLS.documentation.home}
+              variant="ghost"
+              className={ghostOnDark}
+            >
+              Browse the docs
+            </Button>,
+          ]}
+        />
+      </PageSection>
+    </>
+  )
+}
+
+export const metadata = createMetadata({
+  title: SHOWCASE_SEO.title,
+  description: SHOWCASE_SEO.description,
+  path: PATHS.SHOWCASE.path,
+})

--- a/src/app/showcase/utils/generate-structured-data.ts
+++ b/src/app/showcase/utils/generate-structured-data.ts
@@ -1,0 +1,80 @@
+import type { CollectionPage, ItemList, ListItem } from 'schema-dts'
+
+import type { WebPageGraph } from '@/components/StructuredDataScript'
+
+import { PATHS } from '@/constants/paths'
+import { BASE_URL } from '@/constants/site-metadata'
+import type { StructuredDataParams } from '@/types/structured-data-params'
+import { generatePageStructuredData } from '@/utils/generate-page-structured-data'
+
+export type ShowcaseListItem = {
+  title: string
+  description: string
+  url: string
+}
+
+type GraphNodeWithMainEntity = {
+  mainEntity?: { '@id': string }
+}
+
+type ShowcaseItemList = ItemList & {
+  '@id': string
+}
+
+export function generateStructuredData(
+  seo: StructuredDataParams,
+  items: Array<ShowcaseListItem> = [],
+): WebPageGraph {
+  const structuredData = generatePageStructuredData({
+    title: seo.title,
+    description: seo.description,
+    path: PATHS.SHOWCASE.path,
+    pageType: 'CollectionPage',
+  })
+
+  if (items.length === 0) {
+    return structuredData
+  }
+
+  const itemList = generateShowcaseItemList(items)
+  const collectionPage = findGraphNodeByType<
+    CollectionPage & GraphNodeWithMainEntity
+  >(structuredData, 'CollectionPage')
+
+  if (collectionPage) {
+    collectionPage.mainEntity = { '@id': itemList['@id'] }
+  }
+
+  structuredData['@graph'].push(itemList)
+
+  return structuredData
+}
+
+function generateShowcaseItemList(
+  items: Array<ShowcaseListItem>,
+): ShowcaseItemList {
+  const itemListElement: ListItem[] = items.map((item, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    url: item.url,
+    name: item.title,
+    description: item.description,
+  }))
+
+  return {
+    '@type': 'ItemList',
+    '@id': `${BASE_URL}${PATHS.SHOWCASE.path}/#showcase`,
+    name: 'Projects built with Filecoin Onchain Cloud',
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: items.length,
+    itemListElement,
+  }
+}
+
+function findGraphNodeByType<T>(structuredData: WebPageGraph, type: string) {
+  return structuredData['@graph'].find((node) => {
+    const nodeType = (node as { '@type'?: string | Array<string> })['@type']
+
+    return Array.isArray(nodeType) ? nodeType.includes(type) : nodeType === type
+  }) as T | undefined
+}

--- a/src/components/Navigation/constants/navigation.ts
+++ b/src/components/Navigation/constants/navigation.ts
@@ -22,6 +22,11 @@ export const headerNavigationItems: Array<NavItem | NavigationMenuItem> = [
         title: 'Resources',
         links: [
           {
+            description: 'Demos, SDKs, and agent tools built on FOC',
+            label: PATHS.SHOWCASE.label,
+            href: PATHS.SHOWCASE.path,
+          },
+          {
             description: 'Learn about the Filecoin Agents program',
             label: PATHS.AGENTS.label,
             href: PATHS.AGENTS.path,
@@ -61,6 +66,10 @@ export const mobileNavigationItems: Array<NavItem> = [
   {
     label: PATHS.SERVICE_PROVIDERS.label,
     href: PATHS.SERVICE_PROVIDERS.path,
+  },
+  {
+    label: PATHS.SHOWCASE.label,
+    href: PATHS.SHOWCASE.path,
   },
   {
     label: PATHS.AGENTS.label,

--- a/src/components/ShowcaseCard.tsx
+++ b/src/components/ShowcaseCard.tsx
@@ -1,0 +1,56 @@
+import { Badge, type BadgeProps } from '@filecoin-foundation/ui-filecoin/Badge'
+import { CTALink } from '@filecoin-foundation/ui-filecoin/CTALink'
+import { Heading } from '@filecoin-foundation/ui-filecoin/Heading'
+import { GithubLogoIcon } from '@phosphor-icons/react/dist/ssr'
+
+type ShowcaseLink = {
+  href: string
+  label: string
+}
+
+export type ShowcaseCardData = {
+  title: string
+  description: string
+  badge: {
+    text: string
+    variant: BadgeProps['variant']
+  }
+  primary?: ShowcaseLink
+  source?: ShowcaseLink
+}
+
+export function ShowcaseCard({
+  title,
+  description,
+  badge,
+  primary,
+  source,
+}: ShowcaseCardData) {
+  return (
+    <li className="group flex h-full w-full flex-col overflow-hidden rounded-2xl border border-(--color-border-base) bg-(--color-card-background) p-8 transition duration-200 ease-out hover:-translate-y-1 hover:border-brand-600 hover:bg-(--color-card-background-hover) hover:shadow-lg hover:shadow-zinc-950/5 focus-within:brand-outline">
+      <div className="mb-6 flex">
+        <Badge variant={badge.variant} textTransform="none">
+          {badge.text}
+        </Badge>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <span className="group-focus-within:text-(--color-card-heading-hover) group-hover:text-(--color-card-heading-hover)">
+          <Heading tag="h3" variant="card-heading">
+            {title}
+          </Heading>
+        </span>
+        <p className="text-(--color-paragraph-text)">{description}</p>
+      </div>
+
+      <div className="mt-auto flex flex-wrap items-center gap-x-6 gap-y-2 pt-6">
+        {primary && <CTALink href={primary.href}>{primary.label}</CTALink>}
+        {source && (
+          <CTALink href={source.href} icon={GithubLogoIcon}>
+            {source.label}
+          </CTALink>
+        )}
+      </div>
+    </li>
+  )
+}

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -26,6 +26,10 @@ export const PATHS = {
     path: '/service-providers',
     label: 'Service Providers',
   },
+  SHOWCASE: {
+    path: '/showcase',
+    label: 'Showcase',
+  },
   SUPPORT: {
     path: '/support',
     label: 'Support',


### PR DESCRIPTION
## 📝 Description

New **/showcase** route under the Resources nav surfacing what is built on Filecoin Onchain Cloud: agent resources (CLI, MCP server, skill), official SDKs and reference apps, and community demos. Each card links to its live demo and source, and the route is wired into navigation, metadata, and the sitemap.

**Context / motivation:** The site had no single place to point builders to demos, SDKs, and agent tooling built on FOC, and the parent issue (GER-992) specifically asked for a direct, linkable home for "how do my agents use FOC" (CLI + MCP + skill). This page answers both: a curated, verified gallery that builders can explore and fork.

- **Type:** New feature

Closes #282

## 🛠️ Key Changes

- Added the `/showcase` route (`src/app/showcase/`): page, per-section data files, SEO constants, and structured data (CollectionPage + ItemList).
- New `ShowcaseCard` component reusing the design-system card chrome (border, radius, `--color-card-*` tokens, `focus-within:brand-outline`) with a subtle hover (lift + brand border + soft shadow); no new dependencies.
- Three sections: **Plug your agents into Filecoin** (FOC CLI, FOC Storage MCP Server, FOC Storage Skill), **SDKs & reference apps** (Synapse SDK, FOC Upload dApp, Filecoin Pin, Synapse Playground, Synapse Go, Pynapse), **Built by the community** (Filosign, W3Stor, Engram SDK, Compose Mesh, Spawn Protocol, FilCraft, EJENTS, Claw Vault, Filify, dMail, Agentex).
- Wired the route into navigation (Resources dropdown + mobile menu), page metadata, and the sitemap (auto-derived from `PATHS`).
- Badges use the brand palette only: solid for the flagship agent-resources row, brand outline for the rest.
- Copy kept minimal and free of em dashes; only projects on the FOC stack (Synapse SDK, Filecoin Pin, or Filecoin Pay) are included.

## 📌 To-Do Before Merging

- [ ] Confirm the final project list (any additions or removals).
- [ ] Confirm Filosign links to the live app only (its repo is private), and that dMail links to its repo only (live URL was unverified).
- [ ] Decide whether to add per-project logos later (cards are currently badge-based).
- [ ] Re-check all external links resolve at merge time.

## 🧪 How to Test

- **Setup:** `nvm use && npm install && npm run dev`, then open `http://localhost:3000/showcase`.
- **Steps to Test:**
  1. Open the **Resources** nav dropdown (desktop) and the mobile menu; confirm **Showcase** appears and routes to `/showcase`.
  2. Scroll the three sections and confirm cards render with consistent brand badges and even spacing.
  3. Click "View on npm / Try the demo / Open the app" and "View code" links; confirm they open the correct live demo and GitHub source in a new tab.
  4. Hover a card and confirm the lift, brand border, soft shadow, and heading color change.
  5. Resize to mobile/tablet widths and confirm the grid reflows cleanly.
  6. Run `npm run lint` and `npm run build`.
- **Expected Results:** Page builds as a static route, lint passes, all links resolve, and the styling matches the rest of the site.
- **Additional Notes:** Structured data is emitted as a `CollectionPage` with an `ItemList` of all showcased projects; the route is included in `sitemap.xml`.

## 📸 Screenshots

<img width="1650" height="1054" alt="Screenshot 2026-06-30 at 2 29 51 PM" src="https://github.com/user-attachments/assets/bc29d138-15e0-4d68-97ce-51608da5a7e6" />
<img width="1650" height="1054" alt="Screenshot 2026-06-30 at 2 30 05 PM" src="https://github.com/user-attachments/assets/6913f1fc-8c51-4614-b5e0-0b7f531655bc" />
<img width="1650" height="1054" alt="Screenshot 2026-06-30 at 2 30 16 PM" src="https://github.com/user-attachments/assets/a465f5ec-c4e8-49b9-8e45-33d8849d8419" />
