### PR TITLE
fix: move contact support guidance below form

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -34,6 +34,8 @@ export default function Contact() {
       <PageSection backgroundVariant="light" paddingVariant="topNone">
         <Container>
           <div className="mx-auto max-w-2xl space-y-10">
+            <ContactForm />
+
             <section
               aria-labelledby="technical-support-heading"
               className="border-y border-(--color-border-base) py-8"
@@ -49,13 +51,6 @@ export default function Contact() {
                   <p className="text-(--color-paragraph-text)">
                     Use the channel that best matches what you need.
                   </p>
-                  <p className="text-(--color-paragraph-text)">
-                    For the full list of support and community channels, see the{' '}
-                    <SmartTextLink href={PATHS.SUPPORT.path}>
-                      Support page
-                    </SmartTextLink>
-                    .
-                  </p>
                 </div>
 
                 <ul className="space-y-3 text-(--color-paragraph-text)">
@@ -63,7 +58,7 @@ export default function Contact() {
                     <strong className="font-medium text-(--color-text-base)">
                       Quick troubleshooting:
                     </strong>{' '}
-                    join the{' '}
+                    Join the{' '}
                     <ExternalTextLink href={FOC_URLS.social.slack}>
                       #fil-foc channel on Filecoin Slack
                     </ExternalTextLink>
@@ -76,7 +71,7 @@ export default function Contact() {
                     <ExternalTextLink
                       href={FOC_URLS.filecoinCloud.problemReports}
                     >
-                      report a FOC problem on GitHub
+                      Report a FOC problem on GitHub
                     </ExternalTextLink>
                     .
                   </li>
@@ -84,23 +79,23 @@ export default function Contact() {
                     <strong className="font-medium text-(--color-text-base)">
                       Outages or active incidents:
                     </strong>{' '}
-                    check the{' '}
+                    Check the{' '}
                     <ExternalTextLink href={FOC_URLS.status}>
                       Filecoin Cloud status page
                     </ExternalTextLink>
                     .
                   </li>
-                  <li>
-                    <strong className="font-medium text-(--color-text-base)">
-                      Use cases or product feedback:
-                    </strong>{' '}
-                    send the team a note below.
-                  </li>
                 </ul>
+
+                <p className="text-(--color-paragraph-text)">
+                  For the full list of support and community channels, see the{' '}
+                  <SmartTextLink href={PATHS.SUPPORT.path}>
+                    Support page
+                  </SmartTextLink>
+                  .
+                </p>
               </div>
             </section>
-
-            <ContactForm />
           </div>
         </Container>
       </PageSection>


### PR DESCRIPTION
## Summary
- Move the technical support guidance below the contact form.
- Move the Support page link below the outage/status guidance.
- Remove the product feedback/use-cases support bullet and lightly polish action text for readability.

## Validation
- `npm run lint`
- `npm run build`

## Screenshot
![Contact page with support guidance below form](https://raw.githubusercontent.com/nalacateria/filecoin-cloud/pr-assets/move-contact-support-section/pr-screenshots/contact-support-below-form.png)
