### PR TITLE
Temporarily hide the Service Providers page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,15 @@ const nextConfig: NextConfig = {
   images: {
     qualities: [75, 100],
   },
+  async redirects() {
+    return [
+      {
+        source: '/service-providers',
+        destination: '/',
+        permanent: false,
+      },
+    ]
+  },
   webpack: (config) => {
     config.module.rules.push(svgrRule)
     config.module.rules.push(markdownRule)

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,8 @@ const nextConfig: NextConfig = {
   },
   async redirects() {
     return [
+      // Page temporarily hidden; route code kept at src/app/service-providers.
+      // Remove this entry to restore it.
       {
         source: '/service-providers',
         destination: '/',

--- a/src/app/(homepage)/data/filecoin-onchain-cloud-products.ts
+++ b/src/app/(homepage)/data/filecoin-onchain-cloud-products.ts
@@ -4,7 +4,6 @@ import { PATHS } from '@/constants/paths'
 import { FIL_BEAM_URL, FOC_URLS } from '@/constants/site-metadata'
 import aurora from '@/public/assets/aurora.webp'
 import spaceStation from '@/public/assets/space-station.webp'
-import spiralGalaxy from '@/public/assets/spiral-galaxy.webp'
 import stellarExplosionNebula from '@/public/assets/stellar-explosion-nebula.webp'
 
 const CTA_TEXT = 'Learn more'
@@ -47,16 +46,6 @@ export const filecoinOnchainCloudProducts: Array<SimpleCardWithImageProps> = [
     image: {
       data: aurora,
       alt: "View of colorful aurora over Earth's atmosphere seen from space with part of a spacecraft arm visible.",
-    },
-  },
-  {
-    title: 'Service Providers',
-    description:
-      'A global network of operators running Filecoin Onchain Cloud nodes delivering resilient, high-availability storage infrastructure.',
-    cta: { href: PATHS.SERVICE_PROVIDERS.path, text: CTA_TEXT },
-    image: {
-      data: spiralGalaxy,
-      alt: 'Bright spiral galaxy with glowing core and extended spiral arms filled with stars.',
     },
   },
 ] as const satisfies Array<SimpleCardWithImageProps>

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -143,7 +143,7 @@ export default function Homepage() {
           title="Compose the Building Blocks"
           description="Modular services you can mix, match, and deploy, all built for openness, performance, and control."
         >
-          <CardGrid as="ul" variant="smTwoXlFourWider">
+          <CardGrid as="ul" variant="smTwoLgThreeWider">
             {filecoinOnchainCloudProducts.map(
               ({ title, description, cta, image }) => (
                 <SimpleCardWithImage

--- a/src/app/service-providers/page.tsx
+++ b/src/app/service-providers/page.tsx
@@ -9,6 +9,8 @@ import { ServiceProvidersClient } from './components/ServiceProvidersClient'
 import { SERVICE_PROVIDERS_SEO } from './constants/seo'
 import { generateStructuredData } from './utils/generate-structured-data'
 
+// Unreachable: redirected to "/" in next.config.ts while this page is hidden.
+// Kept in place so it can be restored by removing that redirect.
 export default function ServiceProviders() {
   return (
     <>

--- a/src/app/warm-storage-service/components/WarmStorageServicesClient.tsx
+++ b/src/app/warm-storage-service/components/WarmStorageServicesClient.tsx
@@ -16,7 +16,6 @@ import { Navigation } from '@/components/Navigation/Navigation'
 import { ProvidersEmptyLoadingState } from '@/components/ProvidersEmptyLoadingState'
 import { ProvidersLoadingError } from '@/components/ProvidersLoadingError'
 
-import { PATHS } from '@/constants/paths'
 import { FIL_BEAM_URL, FOC_URLS } from '@/constants/site-metadata'
 import { getNetworkId } from '@/utils/get-network-id'
 
@@ -128,16 +127,10 @@ export function WarmStorageServicesClient({
 
       <PageSection backgroundVariant="light">
         <SectionContent
-          centerCTA
           centerTitle
           headingTag="h2"
           title="Warm Storage Details"
           description="View contract addresses and browse approved storage providers."
-          cta={
-            <Button href={PATHS.SERVICE_PROVIDERS.path} variant="ghost">
-              View all service providers
-            </Button>
-          }
         >
           <div className="flex flex-col gap-6">
             <div className="flex items-center justify-between flex-wrap gap-4">

--- a/src/components/Navigation/constants/navigation.ts
+++ b/src/components/Navigation/constants/navigation.ts
@@ -12,10 +12,6 @@ export const headerNavigationItems: Array<NavItem | NavigationMenuItem> = [
     href: PATHS.WARM_STORAGE_SERVICE.path,
   },
   {
-    label: PATHS.SERVICE_PROVIDERS.label,
-    href: PATHS.SERVICE_PROVIDERS.path,
-  },
-  {
     label: 'Resources',
     items: [
       {
@@ -62,10 +58,6 @@ export const mobileNavigationItems: Array<NavItem> = [
   {
     label: PATHS.WARM_STORAGE_SERVICE.label,
     href: PATHS.WARM_STORAGE_SERVICE.path,
-  },
-  {
-    label: PATHS.SERVICE_PROVIDERS.label,
-    href: PATHS.SERVICE_PROVIDERS.path,
   },
   {
     label: PATHS.SHOWCASE.label,


### PR DESCRIPTION
## Summary
- Add a redirect from `/service-providers` to `/` so existing bookmarks/links land on the homepage instead of a broken/stale page.
- Remove the "Service Providers" link from the header and mobile navigation.
- Remove the "Service Providers" card from the homepage product grid.
- Remove the "View all service providers" CTA on the Warm Storage Service page (its own provider table is untouched).

The page code under `src/app/service-providers/` is left in place so this is easy to revert once the page is ready to be brought back — see internal Slack discussion for context.

## Test plan
- [x] `npm run build` succeeds
- [x] `biome check` passes on changed files
- [x] Manually verified in a local dev server:
  - `/service-providers` returns a 307 redirect to `/`
  - Homepage no longer shows the Service Providers card
  - Header/mobile nav no longer shows a Service Providers link
  - `/warm-storage-service` still renders correctly without the removed CTA