### PR TITLE
fix(ipfs2filecoin): design review follow-ups for the landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ next-env.d.ts
 
 # Local test fixtures, not part of the site
 dapper-labs-nba-topshots-cids.txt
+CLAUDE.md
+todo.md

--- a/src/app/ipfs2filecoin/components/AgentPrompt.tsx
+++ b/src/app/ipfs2filecoin/components/AgentPrompt.tsx
@@ -1,38 +1,54 @@
 'use client'
 
-import { Button } from '@filecoin-foundation/ui-filecoin/Button'
+import { Icon } from '@filecoin-foundation/ui-filecoin/Icon'
+import { CheckIcon, CopyIcon } from '@phosphor-icons/react/dist/ssr'
 import { usePlausible } from 'next-plausible'
 
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 
-import { AGENT_PROMPT, PLAUSIBLE_EVENTS } from '../constants/migration'
+import { buildAgentPrompt, PLAUSIBLE_EVENTS } from '../constants/migration'
 
 type AgentPromptProps = {
   /** Where on the page the prompt was copied from, so the two spots stay distinguishable. */
   source: 'verdict' | 'agent-door'
+  /**
+   * The user's checked list. When present it is inlined into the prompt so the
+   * copied line carries the actual CIDs instead of pointing at a cids.txt the
+   * user would have to assemble themselves.
+   */
+  cids?: ReadonlyArray<string>
 }
 
-export function AgentPrompt({ source }: AgentPromptProps) {
+export function AgentPrompt({ source, cids }: AgentPromptProps) {
   const { copy, isCopied } = useCopyToClipboard()
   const plausible = usePlausible()
 
+  const prompt = buildAgentPrompt(cids)
+
   async function handleCopy() {
-    const copied = await copy(AGENT_PROMPT)
+    const copied = await copy(prompt)
 
     if (copied) {
-      plausible(PLAUSIBLE_EVENTS.promptCopied, { props: { source } })
+      plausible(PLAUSIBLE_EVENTS.promptCopied, {
+        props: { source, cidCount: cids?.length ?? 0 },
+      })
     }
   }
 
   return (
-    <div className="space-y-3">
-      <code className="block rounded-lg border border-(--color-border-muted) bg-(--color-card-background) p-3 font-mono text-(--color-paragraph-text) text-xs/relaxed">
-        {AGENT_PROMPT}
+    <div className="relative">
+      <code className="block max-h-48 overflow-y-auto whitespace-pre-wrap rounded-lg border border-(--color-border-muted) bg-(--color-card-background) p-3 pr-12 font-mono text-(--color-paragraph-text) text-xs/relaxed">
+        {prompt}
       </code>
 
-      <Button type="button" variant="ghost" onClick={handleCopy}>
-        {isCopied ? 'Copied' : 'Copy prompt'}
-      </Button>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={isCopied ? 'Prompt copied' : 'Copy prompt'}
+        className="focus-visible:brand-outline absolute top-2 right-2 rounded-md border border-(--color-border-muted) bg-(--color-card-background) p-1.5 text-(--color-paragraph-text) hover:text-(--color-text-base)"
+      >
+        <Icon component={isCopied ? CheckIcon : CopyIcon} size={16} />
+      </button>
 
       <span aria-live="polite" className="sr-only">
         {isCopied ? 'Prompt copied to clipboard' : ''}

--- a/src/app/ipfs2filecoin/components/CidListChecker.tsx
+++ b/src/app/ipfs2filecoin/components/CidListChecker.tsx
@@ -1,84 +1,106 @@
 'use client'
 
 import { Button } from '@filecoin-foundation/ui-filecoin/Button'
-import { SmartTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/SmartTextLink'
-import { Field, Label, Textarea } from '@headlessui/react'
+import { Description, Field, Label, Textarea } from '@headlessui/react'
 import { usePlausible } from 'next-plausible'
-import { useId, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { PATHS } from '@/constants/paths'
-
-import { AgentPrompt } from './AgentPrompt'
+import { CidListVerdict, getVerdict, type Verdict } from './CidListVerdict'
 import {
   BROWSER_CHECK_ITEM_CAP,
   MAX_ITEM_SIZE_LABEL,
   PLAUSIBLE_EVENTS,
 } from '../constants/migration'
-import { type CidListSummary, parseCidList } from '../utils/parse-cid-list'
+import { parseCidList } from '../utils/parse-cid-list'
+import { pluralize } from '../utils/pluralize'
 
-const PLACEHOLDER = [
-  'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
-  'bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq',
-  'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
-].join('\n')
+/**
+ * One line, not three. Three full CIDs fill the field edge to edge and read as
+ * a list already pasted; a single dim example reads as the prompt it is. The
+ * field keeps its height from `min-h`, so it still invites a list.
+ */
+const PLACEHOLDER =
+  'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
 
 /** The free-check facts, broken out so they scan as features rather than fine print. */
 const CHECK_FACTS = [
-  'Free, no wallet',
+  'Free, no wallet required',
   `Up to ${BROWSER_CHECK_ITEM_CAP.toLocaleString()} items`,
   `${MAX_ITEM_SIZE_LABEL} per item`,
   'Runs in your browser',
-  'Your list is never sent anywhere',
+  'Never sent anywhere',
 ]
 
-type Verdict =
-  | { kind: 'empty' }
-  | { kind: 'unreadable'; summary: CidListSummary }
-  | { kind: 'ok'; summary: CidListSummary }
-  | { kind: 'over-cap'; summary: CidListSummary }
+/**
+ * The submit shortcut accepts Cmd or Ctrl, so the chip has to name whichever
+ * one this visitor actually has. Resolved after mount rather than rendered on
+ * the server, which has no way to know: `null` until then keeps the first
+ * client render identical to the server's and avoids a hydration mismatch.
+ */
+function useShortcutLabel() {
+  const [label, setLabel] = useState<string | null>(null)
 
-function getVerdict(summary: CidListSummary): Verdict {
-  if (summary.totalLines === 0) {
-    return { kind: 'empty' }
-  }
-  if (summary.uniqueCids.length === 0) {
-    return { kind: 'unreadable', summary }
-  }
-  if (summary.uniqueCids.length > BROWSER_CHECK_ITEM_CAP) {
-    return { kind: 'over-cap', summary }
-  }
-  return { kind: 'ok', summary }
+  useEffect(() => {
+    const isApple = /mac|iphone|ipad|ipod/i.test(
+      navigator.platform || navigator.userAgent,
+    )
+    setLabel(isApple ? '⌘ ↵' : 'Ctrl ↵')
+  }, [])
+
+  return label
 }
 
-function pluralize(count: number, singular: string, plural = `${singular}s`) {
-  return count === 1 ? singular : plural
-}
-
-function buildNotes({ invalidCount, duplicateCount }: CidListSummary) {
-  const notes: Array<string> = []
-
-  if (invalidCount > 0) {
-    notes.push(
-      `${invalidCount} ${pluralize(invalidCount, 'line')} could not be read as a CID and will be skipped`,
-    )
+/**
+ * What the parser makes of the list as it is typed, so the button confirms a
+ * result the user can already see rather than being the first sign of one.
+ */
+function describeProgress(
+  totalLines: number,
+  recognizedCount: number,
+): string | null {
+  if (totalLines === 0) {
+    return null
   }
-  if (duplicateCount > 0) {
-    notes.push(
-      `${duplicateCount} ${pluralize(duplicateCount, 'duplicate')} removed`,
-    )
+  if (recognizedCount === 0) {
+    return 'No CIDs recognized yet'
+  }
+  if (recognizedCount === totalLines) {
+    return `${recognizedCount.toLocaleString()} ${pluralize(recognizedCount, 'CID')}`
   }
 
-  return notes.length > 0 ? `${notes.join('. ')}.` : null
+  return `${recognizedCount.toLocaleString()} of ${totalLines.toLocaleString()} lines are CIDs`
 }
 
 export function CidListChecker() {
-  const inputId = useId()
   const plausible = usePlausible()
   const [value, setValue] = useState('')
   const [verdict, setVerdict] = useState<Verdict | null>(null)
+  const verdictRef = useRef<HTMLDivElement>(null)
+
+  const shortcutLabel = useShortcutLabel()
+  const summary = useMemo(() => parseCidList(value), [value])
+  const hasInput = value.trim().length > 0
+  const progress = describeProgress(
+    summary.totalLines,
+    summary.uniqueCids.length,
+  )
+
+  /**
+   * The panel lands below the fold on a laptop, so a check would otherwise look
+   * like it did nothing. Aligning its bottom edge reveals the whole result while
+   * leaving the list itself in view, which `nearest` does not: for an element
+   * taller than the gap below it, the minimum scroll is barely any scroll.
+   */
+  useEffect(() => {
+    if (verdict) {
+      verdictRef.current?.scrollIntoView({
+        block: 'end',
+        behavior: 'smooth',
+      })
+    }
+  }, [verdict])
 
   function handleCheck() {
-    const summary = parseCidList(value)
     const next = getVerdict(summary)
     setVerdict(next)
 
@@ -97,135 +119,88 @@ export function CidListChecker() {
   return (
     <div className="mx-auto w-full max-w-2xl text-left">
       <Field>
-        <Label
-          htmlFor={inputId}
-          className="mb-2 flex flex-wrap items-baseline gap-x-2 text-(--color-paragraph-text) text-sm"
-        >
-          Paste the CIDs you want to move
-          <span className="font-medium text-brand-500">one per line</span>
-        </Label>
-        <Textarea
-          id={inputId}
-          value={value}
-          spellCheck={false}
-          rows={4}
-          placeholder={PLACEHOLDER}
-          onChange={(event) => setValue(event.target.value)}
-          className="focus:brand-outline block min-h-24 w-full resize-y rounded-lg border border-(--input-border-color) p-3 font-mono text-(--color-text-base) text-sm placeholder:text-(--input-placeholder-color)"
-        />
+        {/*
+          One enclosed surface rather than a label, a field and an action loose
+          on the page: the border is what says "this is the thing you use". The
+          header and footer bars carry the supporting text, so the input itself
+          stays uninterrupted.
+        */}
+        <div className="overflow-hidden rounded-xl border border-(--color-border-muted) bg-(--color-card-background) transition-colors has-[textarea:focus]:border-brand-600 has-[textarea:focus]:ring-1 has-[textarea:focus]:ring-brand-600">
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 px-4 pt-3">
+            <Label className="font-medium text-(--color-text-base) text-sm">
+              Paste the CIDs you want to move
+            </Label>
+            {progress && (
+              <span
+                aria-live="polite"
+                className="text-(--color-paragraph-text) text-xs tabular-nums"
+              >
+                {progress}
+              </span>
+            )}
+          </div>
+
+          {/*
+            One entry per visual row: soft wrapping would render a long gateway
+            URL as two rows and contradict the line count in the header, so long
+            lines scroll sideways instead, the way a code editor holds them.
+          */}
+          <Textarea
+            value={value}
+            spellCheck={false}
+            wrap="off"
+            placeholder={PLACEHOLDER}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                handleCheck()
+              }
+            }}
+            className="mt-2 block max-h-64 min-h-16 w-full resize-none overflow-auto whitespace-pre field-sizing-content border-0 bg-transparent px-4 pb-3 font-mono text-(--color-text-base) text-sm/relaxed placeholder:text-(--color-paragraph-text-subtle) focus:outline-none"
+          />
+
+          <div className="flex flex-col items-stretch gap-3 border-(--color-border-muted) border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-x-4">
+            <Description className="text-(--color-paragraph-text) text-xs">
+              One per line. Gateway URLs are fine, the prefix is stripped.
+            </Description>
+            <Button
+              type="button"
+              variant="primary"
+              size="compact"
+              onClick={handleCheck}
+              disabled={!hasInput}
+              className="w-full sm:w-auto"
+            >
+              Check my list
+              {/* Pointer-only: a shortcut is noise without a modifier key. */}
+              {shortcutLabel && (
+                <kbd className="ml-2 hidden rounded border border-(--color-border-base) px-1 py-px font-sans text-(--color-paragraph-text) text-xs/none sm:inline">
+                  {shortcutLabel}
+                </kbd>
+              )}
+            </Button>
+          </div>
+        </div>
       </Field>
 
-      <div className="mt-3 flex justify-center">
-        <Button type="button" variant="primary" onClick={handleCheck}>
-          Check my list
-        </Button>
-      </div>
-
+      {/* Directly under the control that produced it: the reassurance below is
+          what you read before deciding, not between a question and its answer. */}
       {verdict && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="mt-4 rounded-lg border border-(--color-border-muted) bg-(--color-card-background) p-4 text-(--color-paragraph-text) text-sm"
-        >
-          <VerdictMessage verdict={verdict} />
+        <div ref={verdictRef} className="mt-3 scroll-mb-6">
+          <CidListVerdict verdict={verdict} />
         </div>
       )}
 
-      <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-(--color-paragraph-text) text-sm">
+      <ul className="mt-3 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-(--color-paragraph-text) text-xs">
         {CHECK_FACTS.map((fact) => (
-          <li key={fact}>{fact}</li>
+          <li
+            key={fact}
+            className="flex items-center gap-2 before:text-(--color-border-base) before:content-['•'] first:before:hidden"
+          >
+            {fact}
+          </li>
         ))}
       </ul>
-
-      <p className="mt-2 text-(--color-paragraph-text) text-sm/relaxed">
-        Past that,{' '}
-        <SmartTextLink href={`${PATHS.IPFS_TO_FILECOIN.path}#agent`}>
-          hand the migration to your agent
-        </SmartTextLink>
-        .
-      </p>
-    </div>
-  )
-}
-
-/** Offers the cleaned, deduped list as the cids.txt the runbook expects. */
-function DownloadCidsLink({ cids }: { cids: ReadonlyArray<string> }) {
-  const href = `data:text/plain;charset=utf-8,${encodeURIComponent(`${cids.join('\n')}\n`)}`
-
-  return (
-    <a
-      href={href}
-      download="cids.txt"
-      className="text-link focus-visible:brand-outline"
-    >
-      Download cids.txt
-    </a>
-  )
-}
-
-function VerdictMessage({ verdict }: { verdict: Verdict }) {
-  if (verdict.kind === 'empty') {
-    return (
-      <p>
-        <strong className="font-medium text-(--color-text-base)">
-          Nothing to check yet.
-        </strong>{' '}
-        Paste one CID per line.
-      </p>
-    )
-  }
-
-  const { summary } = verdict
-  const notes = buildNotes(summary)
-  const count = summary.uniqueCids.length
-
-  if (verdict.kind === 'unreadable') {
-    return (
-      <p>
-        <strong className="font-medium text-(--color-text-base)">
-          None of these look like CIDs.
-        </strong>{' '}
-        {summary.totalLines} {pluralize(summary.totalLines, 'line')} could not
-        be read as a CID. Check for extra text, URLs, or commas.
-      </p>
-    )
-  }
-
-  if (verdict.kind === 'over-cap') {
-    return (
-      <div className="space-y-3">
-        <p>
-          <strong className="font-medium text-(--color-text-base)">
-            {count.toLocaleString()} CIDs is more than a browser check handles.
-          </strong>{' '}
-          The limit here is {BROWSER_CHECK_ITEM_CAP.toLocaleString()} items.
-          Hand the list to your agent instead: no cap, and it resumes if it
-          stops. {notes}
-        </p>
-        <DownloadCidsLink cids={summary.uniqueCids} />
-        <AgentPrompt source="verdict" />
-      </div>
-    )
-  }
-
-  return (
-    <div className="space-y-3">
-      <p>
-        <strong className="font-medium text-(--color-text-base)">
-          {count.toLocaleString()} {pluralize(count, 'CID')} ready.
-        </strong>{' '}
-        Give this line to your agent and it will fetch each one, measure it, and
-        migrate it. {notes}
-      </p>
-      <AgentPrompt source="verdict" cids={summary.uniqueCids} />
-      <p>
-        <DownloadCidsLink cids={summary.uniqueCids} />
-      </p>
-      <p className="text-(--color-paragraph-text-subtle)">
-        A check reads the CIDs themselves, not the data behind them, so it
-        cannot tell how many bytes you are holding. Enter that in the estimator
-        below to price it.
-      </p>
     </div>
   )
 }

--- a/src/app/ipfs2filecoin/components/CidListChecker.tsx
+++ b/src/app/ipfs2filecoin/components/CidListChecker.tsx
@@ -22,6 +22,15 @@ const PLACEHOLDER = [
   'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
 ].join('\n')
 
+/** The free-check facts, broken out so they scan as features rather than fine print. */
+const CHECK_FACTS = [
+  'Free, no wallet',
+  `Up to ${BROWSER_CHECK_ITEM_CAP.toLocaleString()} items`,
+  `${MAX_ITEM_SIZE_LABEL} per item`,
+  'Runs in your browser',
+  'Your list is never sent anywhere',
+]
+
 type Verdict =
   | { kind: 'empty' }
   | { kind: 'unreadable'; summary: CidListSummary }
@@ -90,22 +99,23 @@ export function CidListChecker() {
       <Field>
         <Label
           htmlFor={inputId}
-          className="mb-2 inline-block text-(--color-paragraph-text) text-sm"
+          className="mb-2 flex flex-wrap items-baseline gap-x-2 text-(--color-paragraph-text) text-sm"
         >
           Paste the CIDs you want to move
+          <span className="font-medium text-brand-500">one per line</span>
         </Label>
         <Textarea
           id={inputId}
           value={value}
           spellCheck={false}
-          rows={5}
+          rows={4}
           placeholder={PLACEHOLDER}
           onChange={(event) => setValue(event.target.value)}
-          className="focus:brand-outline block min-h-32 w-full resize-y rounded-lg border border-(--input-border-color) p-3 font-mono text-(--color-text-base) text-sm placeholder:text-(--input-placeholder-color)"
+          className="focus:brand-outline block min-h-24 w-full resize-y rounded-lg border border-(--input-border-color) p-3 font-mono text-(--color-text-base) text-sm placeholder:text-(--input-placeholder-color)"
         />
       </Field>
 
-      <div className="mt-3">
+      <div className="mt-3 flex justify-center">
         <Button type="button" variant="primary" onClick={handleCheck}>
           Check my list
         </Button>
@@ -121,17 +131,35 @@ export function CidListChecker() {
         </div>
       )}
 
-      <p className="mt-3 text-(--color-paragraph-text) text-sm/relaxed">
-        Checking is free and needs no wallet, up to{' '}
-        {BROWSER_CHECK_ITEM_CAP.toLocaleString()} items and{' '}
-        {MAX_ITEM_SIZE_LABEL} per item. It runs entirely in your browser, so
-        your list is never sent anywhere. Past that,{' '}
+      <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-(--color-paragraph-text) text-sm">
+        {CHECK_FACTS.map((fact) => (
+          <li key={fact}>{fact}</li>
+        ))}
+      </ul>
+
+      <p className="mt-2 text-(--color-paragraph-text) text-sm/relaxed">
+        Past that,{' '}
         <SmartTextLink href={`${PATHS.IPFS_TO_FILECOIN.path}#agent`}>
           hand the migration to your agent
         </SmartTextLink>
         .
       </p>
     </div>
+  )
+}
+
+/** Offers the cleaned, deduped list as the cids.txt the runbook expects. */
+function DownloadCidsLink({ cids }: { cids: ReadonlyArray<string> }) {
+  const href = `data:text/plain;charset=utf-8,${encodeURIComponent(`${cids.join('\n')}\n`)}`
+
+  return (
+    <a
+      href={href}
+      download="cids.txt"
+      className="text-link focus-visible:brand-outline"
+    >
+      Download cids.txt
+    </a>
   )
 }
 
@@ -174,18 +202,30 @@ function VerdictMessage({ verdict }: { verdict: Verdict }) {
           Hand the list to your agent instead: no cap, and it resumes if it
           stops. {notes}
         </p>
+        <DownloadCidsLink cids={summary.uniqueCids} />
         <AgentPrompt source="verdict" />
       </div>
     )
   }
 
   return (
-    <p>
-      <strong className="font-medium text-(--color-text-base)">
-        {count.toLocaleString()} {pluralize(count, 'CID')} ready to check.
-      </strong>{' '}
-      Estimate what they cost to store below, then hand the list to your agent
-      to fetch, measure, and migrate them. {notes}
-    </p>
+    <div className="space-y-3">
+      <p>
+        <strong className="font-medium text-(--color-text-base)">
+          {count.toLocaleString()} {pluralize(count, 'CID')} ready.
+        </strong>{' '}
+        Give this line to your agent and it will fetch each one, measure it, and
+        migrate it. {notes}
+      </p>
+      <AgentPrompt source="verdict" cids={summary.uniqueCids} />
+      <p>
+        <DownloadCidsLink cids={summary.uniqueCids} />
+      </p>
+      <p className="text-(--color-paragraph-text-subtle)">
+        A check reads the CIDs themselves, not the data behind them, so it
+        cannot tell how many bytes you are holding. Enter that in the estimator
+        below to price it.
+      </p>
+    </div>
   )
 }

--- a/src/app/ipfs2filecoin/components/CidListVerdict.tsx
+++ b/src/app/ipfs2filecoin/components/CidListVerdict.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { Icon } from '@filecoin-foundation/ui-filecoin/Icon'
+import { SmartTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/SmartTextLink'
+import {
+  CheckCircleIcon,
+  InfoIcon,
+  WarningCircleIcon,
+} from '@phosphor-icons/react/dist/ssr'
+
+import { PATHS } from '@/constants/paths'
+
+import { AgentPrompt } from './AgentPrompt'
+import { BROWSER_CHECK_ITEM_CAP } from '../constants/migration'
+import type { CidListSummary } from '../utils/parse-cid-list'
+import { pluralize } from '../utils/pluralize'
+
+export type Verdict =
+  | { kind: 'empty' }
+  | { kind: 'unreadable'; summary: CidListSummary }
+  | { kind: 'ok'; summary: CidListSummary }
+  | { kind: 'over-cap'; summary: CidListSummary }
+
+export function getVerdict(summary: CidListSummary): Verdict {
+  if (summary.totalLines === 0) {
+    return { kind: 'empty' }
+  }
+  if (summary.uniqueCids.length === 0) {
+    return { kind: 'unreadable', summary }
+  }
+  if (summary.uniqueCids.length > BROWSER_CHECK_ITEM_CAP) {
+    return { kind: 'over-cap', summary }
+  }
+  return { kind: 'ok', summary }
+}
+
+/**
+ * Tone per outcome, in tokens rather than literals so the panel survives being
+ * mounted on a light section. Over-cap is informational, not a failure: the
+ * list is fine, it just routes to the agent instead of the browser.
+ */
+const TONE = {
+  empty: { icon: InfoIcon, className: 'text-(--color-paragraph-text)' },
+  unreadable: {
+    icon: WarningCircleIcon,
+    className: 'text-(--color-brand-error)',
+  },
+  'over-cap': { icon: InfoIcon, className: 'text-(--color-paragraph-text)' },
+  ok: { icon: CheckCircleIcon, className: 'text-(--color-icon-success)' },
+} as const
+
+/**
+ * What the parser changed about the list. Kept as separate lines rather than a
+ * run-on sentence, so two adjustments do not read as one.
+ */
+function buildAdjustments({ invalidCount, duplicateCount }: CidListSummary) {
+  const adjustments: Array<string> = []
+
+  if (invalidCount > 0) {
+    adjustments.push(
+      `${invalidCount} ${pluralize(invalidCount, 'line')} skipped, not readable as a CID`,
+    )
+  }
+  if (duplicateCount > 0) {
+    adjustments.push(
+      `${duplicateCount} ${pluralize(duplicateCount, 'duplicate')} removed`,
+    )
+  }
+
+  return adjustments
+}
+
+export function CidListVerdict({ verdict }: { verdict: Verdict }) {
+  const tone = TONE[verdict.kind]
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-2.5 rounded-xl border border-(--color-border-muted) bg-(--color-card-background) p-4"
+    >
+      <span className={`shrink-0 ${tone.className}`}>
+        <Icon component={tone.icon} size={16} />
+      </span>
+      <div className="-mt-0.5 min-w-0 flex-1 space-y-3 text-(--color-paragraph-text) text-sm/relaxed">
+        <VerdictBody verdict={verdict} />
+      </div>
+    </div>
+  )
+}
+
+function Headline({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="font-medium text-(--color-text-base) text-sm tabular-nums">
+      {children}
+    </p>
+  )
+}
+
+function Adjustments({ summary }: { summary: CidListSummary }) {
+  const adjustments = buildAdjustments(summary)
+
+  if (adjustments.length === 0) {
+    return null
+  }
+
+  return (
+    <ul className="space-y-1 text-(--color-paragraph-text) text-xs">
+      {adjustments.map((adjustment) => (
+        <li key={adjustment} className="tabular-nums">
+          {adjustment}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/**
+ * Offers the cleaned, deduped list as the cids.txt the runbook expects. Always
+ * used inside a sentence that says what the file is for: on its own, the
+ * filename tells you nothing about why you would want it.
+ */
+function DownloadCidsLink({
+  cids,
+  label,
+}: {
+  cids: ReadonlyArray<string>
+  label: string
+}) {
+  const href = `data:text/plain;charset=utf-8,${encodeURIComponent(`${cids.join('\n')}\n`)}`
+
+  return (
+    <a
+      href={href}
+      download="cids.txt"
+      className="text-link focus-visible:brand-outline"
+    >
+      {label}
+    </a>
+  )
+}
+
+function VerdictBody({ verdict }: { verdict: Verdict }) {
+  if (verdict.kind === 'empty') {
+    return (
+      <>
+        <Headline>Nothing to check yet</Headline>
+        <p>Paste one CID per line to get started.</p>
+      </>
+    )
+  }
+
+  const { summary } = verdict
+  const count = summary.uniqueCids.length
+
+  if (verdict.kind === 'unreadable') {
+    return (
+      <>
+        <Headline>None of these look like CIDs</Headline>
+        <p className="tabular-nums">
+          {summary.totalLines} {pluralize(summary.totalLines, 'line')} could not
+          be read as a CID. Check for extra text, commas, or a URL that is not a
+          gateway path.
+        </p>
+      </>
+    )
+  }
+
+  if (verdict.kind === 'over-cap') {
+    return (
+      <>
+        <Headline>
+          {count.toLocaleString()} CIDs is more than a browser check handles
+        </Headline>
+        <Adjustments summary={summary} />
+        <p>
+          The limit here is {BROWSER_CHECK_ITEM_CAP.toLocaleString()} items.
+          Hand the list to your agent instead: no cap, and it resumes if it
+          stops.
+        </p>
+        <AgentPrompt source="verdict" />
+        <p className="text-(--color-paragraph-text) text-xs">
+          That prompt reads your list from a file, so{' '}
+          <DownloadCidsLink
+            cids={summary.uniqueCids}
+            label="download cids.txt"
+          />{' '}
+          and keep it in the folder your agent runs from.
+        </p>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Headline>
+        {count.toLocaleString()} {pluralize(count, 'CID')} ready to migrate
+      </Headline>
+      <Adjustments summary={summary} />
+      <p>
+        Give this line to your agent and it will fetch each one, measure it, and
+        migrate it.
+      </p>
+      <AgentPrompt source="verdict" cids={summary.uniqueCids} />
+      <p className="text-(--color-paragraph-text) text-xs">
+        Running the migration yourself instead?{' '}
+        <DownloadCidsLink cids={summary.uniqueCids} label="Download cids.txt" />{' '}
+        for the same list, cleaned and deduped, in the file the runbook reads.
+      </p>
+      <p className="text-(--color-paragraph-text) text-xs">
+        A check reads the CIDs themselves, not the data behind them, so it
+        cannot tell how many bytes you are holding. Enter that in{' '}
+        <SmartTextLink href={`${PATHS.IPFS_TO_FILECOIN.path}#estimate`}>
+          the deposit estimator
+        </SmartTextLink>{' '}
+        to price it.
+      </p>
+    </>
+  )
+}

--- a/src/app/ipfs2filecoin/components/ComparisonTable.tsx
+++ b/src/app/ipfs2filecoin/components/ComparisonTable.tsx
@@ -5,9 +5,9 @@ import { pricingComparison } from '../data/pricing-comparison'
 export function ComparisonTable() {
   return (
     <div className="overflow-x-auto rounded-xl border border-(--color-border-muted)">
-      <table className="w-full min-w-140 text-left text-sm">
+      <table className="w-full min-w-140 text-left text-base">
         <thead>
-          <tr className="border-(--color-border-muted) border-b text-(--color-paragraph-text)">
+          <tr className="border-(--color-border-muted) border-b text-(--color-paragraph-text) text-sm">
             <th scope="col" className="px-5 py-4 font-medium">
               Where the data lives
             </th>
@@ -26,10 +26,15 @@ export function ComparisonTable() {
                 key={service}
                 className="border-(--color-border-muted) border-b last:border-b-0"
               >
+                {/*
+                  Service names carry the same typeface as the figures on purpose.
+                  They were previously monospace, which read as a size jump and
+                  made the names look smaller than the numbers beside them.
+                */}
                 <th
                   scope="row"
                   className={clsx(
-                    'px-5 py-4 font-normal',
+                    'px-5 py-4 font-normal text-lg',
                     highlighted && 'font-medium text-(--color-text-base)',
                   )}
                 >
@@ -37,13 +42,14 @@ export function ComparisonTable() {
                 </th>
                 <td
                   className={clsx(
-                    'px-5 py-4 font-mono whitespace-nowrap',
-                    highlighted && 'text-(--color-text-base) text-lg',
+                    'whitespace-nowrap px-5 py-4 tabular-nums',
+                    highlighted &&
+                      'font-medium text-(--color-text-base) text-lg',
                   )}
                 >
                   {storagePerTbMonth}
                 </td>
-                <td className="px-5 py-4 font-mono whitespace-nowrap">
+                <td className="whitespace-nowrap px-5 py-4 tabular-nums">
                   {egress}
                 </td>
               </tr>

--- a/src/app/ipfs2filecoin/components/ComparisonTable.tsx
+++ b/src/app/ipfs2filecoin/components/ComparisonTable.tsx
@@ -4,10 +4,70 @@ import { pricingComparison } from '../data/pricing-comparison'
 
 export function ComparisonTable() {
   return (
-    <div className="overflow-x-auto rounded-xl border border-(--color-border-muted)">
+    <>
+      <MobileComparisonCards />
+      <DesktopComparisonTable />
+    </>
+  )
+}
+
+/**
+ * The three columns do not fit a phone, and the egress value is a full sentence
+ * rather than a figure, so the table would clip it and scroll sideways. Each
+ * provider becomes a stacked card instead: the name and tier on top, then the
+ * two figures as labelled rows, so nothing is hidden. The table returns at md,
+ * where the columns have room.
+ */
+function MobileComparisonCards() {
+  return (
+    <ul className="space-y-3 md:hidden">
+      {pricingComparison.map(
+        ({ service, detail, storagePerTbMonth, egress, highlighted }) => (
+          <li
+            key={`${service} ${detail}`}
+            className={clsx(
+              'rounded-xl border border-(--color-border-muted) p-4',
+              highlighted && 'bg-(--color-card-background-hover)',
+            )}
+          >
+            <div
+              className={clsx(
+                highlighted && 'font-semibold text-(--color-text-base)',
+              )}
+            >
+              <p className="text-lg">{service}</p>
+              <p className="mt-0.5 font-normal text-(--color-paragraph-text) text-sm">
+                {detail}
+              </p>
+            </div>
+            <dl className="mt-3 space-y-2 border-(--color-border-muted) border-t pt-3 text-sm text-(--color-paragraph-text)">
+              <div className="flex items-baseline justify-between gap-4">
+                <dt>Storage, per TB per month</dt>
+                <dd className="shrink-0 tabular-nums">{storagePerTbMonth}</dd>
+              </div>
+              <div className="flex items-baseline justify-between gap-4">
+                <dt>Egress</dt>
+                <dd className="text-right">{egress}</dd>
+              </div>
+            </dl>
+          </li>
+        ),
+      )}
+    </ul>
+  )
+}
+
+function DesktopComparisonTable() {
+  return (
+    <div className="hidden overflow-x-auto rounded-xl border border-(--color-border-muted) md:block">
       <table className="w-full min-w-140 text-left text-base">
         <thead>
-          <tr className="border-(--color-border-muted) border-b text-(--color-paragraph-text) text-sm">
+          {/*
+            `card-background-hover` is the only subtle-surface value the token
+            set has: zinc-50 on light sections, a lift rather than a wash on
+            dark ones. Named for hover, used here as a static header tint.
+          */}
+          <tr className="border-(--color-border-muted) border-b bg-(--color-card-background-hover) text-(--color-paragraph-text) text-sm">
             <th scope="col" className="px-5 py-4 font-medium">
               Where the data lives
             </th>
@@ -21,10 +81,16 @@ export function ComparisonTable() {
         </thead>
         <tbody className="text-(--color-paragraph-text)">
           {pricingComparison.map(
-            ({ service, storagePerTbMonth, egress, highlighted }) => (
+            ({ service, detail, storagePerTbMonth, egress, highlighted }) => (
+              // Weight and colour sit on the row so the highlighted line reads
+              // as one emphasised entry rather than two bold cells and a third
+              // that quietly drops back to the body colour.
               <tr
-                key={service}
-                className="border-(--color-border-muted) border-b last:border-b-0"
+                key={`${service} ${detail}`}
+                className={clsx(
+                  'border-(--color-border-muted) border-b last:border-b-0',
+                  highlighted && 'font-semibold text-(--color-text-base)',
+                )}
               >
                 {/*
                   Service names carry the same typeface as the figures on purpose.
@@ -33,18 +99,17 @@ export function ComparisonTable() {
                 */}
                 <th
                   scope="row"
-                  className={clsx(
-                    'px-5 py-4 font-normal text-lg',
-                    highlighted && 'font-medium text-(--color-text-base)',
-                  )}
+                  className={clsx('px-5 py-4', !highlighted && 'font-normal')}
                 >
-                  {service}
+                  <span className="block text-lg">{service}</span>
+                  <span className="mt-0.5 block font-normal text-(--color-paragraph-text) text-sm">
+                    {detail}
+                  </span>
                 </th>
                 <td
                   className={clsx(
                     'whitespace-nowrap px-5 py-4 tabular-nums',
-                    highlighted &&
-                      'font-medium text-(--color-text-base) text-lg',
+                    highlighted && 'text-lg',
                   )}
                 >
                   {storagePerTbMonth}

--- a/src/app/ipfs2filecoin/components/CostEstimator.tsx
+++ b/src/app/ipfs2filecoin/components/CostEstimator.tsx
@@ -71,50 +71,76 @@ export function CostEstimator() {
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,2fr)]">
-        <Field>
-          <Label htmlFor={volumeId} className={labelClassName}>
-            How much data
-          </Label>
-          <Input
-            id={volumeId}
-            type="number"
-            min="0"
-            step="any"
-            inputMode="decimal"
-            value={volume}
-            onChange={(event) => setVolume(event.target.value)}
-            className={fieldClassName}
-          />
-        </Field>
+      {/*
+        Two controls for two questions, sharing one row inside the card. The
+        amount carries its unit inside one bordered box rather than beside a
+        separate field, so "How much data" reads as a single control; the "Unit"
+        label goes with it, since a select holding "TiB" needs no caption. A
+        two-column grid keeps the pair side by side and lets each fill its half
+        rather than being sized to the few characters it holds.
+      */}
+      <div className="space-y-2">
+        <div className="grid grid-cols-2 items-end gap-3">
+          <Field>
+            <Label htmlFor={volumeId} className={labelClassName}>
+              How much data
+            </Label>
+            <div className="focus-within:brand-outline flex w-full items-stretch rounded-lg border border-(--input-border-color)">
+              <Input
+                id={volumeId}
+                type="number"
+                min="0"
+                step="any"
+                inputMode="decimal"
+                value={volume}
+                onChange={(event) => setVolume(event.target.value)}
+                className="w-full min-w-0 border-0 bg-transparent p-3 text-(--color-text-base) focus:outline-none"
+              />
+              <div className="relative flex items-center border-(--input-border-color) border-l">
+                <Select
+                  aria-label="Unit"
+                  value={unit}
+                  onChange={(event) =>
+                    setUnit(event.target.value as VolumeUnit)
+                  }
+                  className="appearance-none bg-transparent py-3 pr-10 pl-3 text-(--color-text-base) focus:outline-none"
+                >
+                  <option value="GiB">GiB</option>
+                  <option value="TiB">TiB</option>
+                </Select>
+                <span className="pointer-events-none absolute right-0 flex items-center pr-3 text-(--color-paragraph-text)">
+                  <Icon component={CaretDownIcon} size={20} />
+                </span>
+              </div>
+            </div>
+          </Field>
 
-        <SelectField
-          label="Unit"
-          value={unit}
-          onChange={(event) => setUnit(event.target.value as VolumeUnit)}
-        >
-          <option value="GiB">GiB</option>
-          <option value="TiB">TiB</option>
-        </SelectField>
-        <p className="text-(--color-paragraph-text-subtle) text-sm sm:col-span-3">
+          <SelectField
+            className="w-full"
+            label="Funded for"
+            value={days}
+            onChange={(event) => setDays(Number(event.target.value))}
+          >
+            {DURATION_OPTIONS.map(({ label, days: value }) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </SelectField>
+        </div>
+
+        <p className="text-(--color-paragraph-text-subtle) text-sm">
           Total across everything you are storing, not per CID. 1 TiB is 1,024
           GiB.
         </p>
-
-        <SelectField
-          label="Funded for"
-          value={days}
-          onChange={(event) => setDays(Number(event.target.value))}
-        >
-          {DURATION_OPTIONS.map(({ label, days: value }) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </SelectField>
       </div>
 
-      <Button type="button" variant="primary" onClick={handleEstimate}>
+      <Button
+        type="button"
+        variant="primary"
+        onClick={handleEstimate}
+        className="w-full"
+      >
         Estimate my deposit
       </Button>
 
@@ -143,6 +169,8 @@ type SelectFieldProps = {
   value: string | number
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void
   children: ReactNode
+  /** Width of the field, set by the caller so it matches what it holds. */
+  className?: string
 }
 
 /**
@@ -150,11 +178,17 @@ type SelectFieldProps = {
  * is replaced so the caret keeps the same inset as the field's text instead of
  * sitting hard against the border.
  */
-function SelectField({ label, value, onChange, children }: SelectFieldProps) {
+function SelectField({
+  label,
+  value,
+  onChange,
+  children,
+  className,
+}: SelectFieldProps) {
   const id = useId()
 
   return (
-    <Field>
+    <Field className={className}>
       <Label htmlFor={id} className={labelClassName}>
         {label}
       </Label>
@@ -184,65 +218,55 @@ function EstimateBreakdown({ estimate }: { estimate: CostEstimate }) {
     {
       label: `Storage and proving for ${durationLabel}`,
       amount: formatUsd(estimate.storage),
-      note: 'No, this is the cost',
+      note: 'Not refundable, this is the cost',
     },
     {
       label: `Buffer held while data is live (${BUFFER_DAYS} days of charges)`,
       amount: formatUsd(estimate.buffer),
-      note: 'Yes, refundable',
+      note: 'Refundable',
     },
     {
       label: 'Lifecycle reserve, per data set',
       amount: formatUsd(estimate.lifecycleReserve),
-      note: 'Yes, unused portion',
+      note: 'Unused portion refundable',
     },
   ]
 
+  // Stacked rather than a table: the card column is too narrow for the
+  // three-column breakdown, so each line reads label over its refundable note
+  // on the left and the figure on the right, the way a receipt totals up.
   return (
     <div
       role="status"
       aria-live="polite"
-      className="overflow-x-auto rounded-xl border border-(--color-border-muted)"
+      className="space-y-4 rounded-xl border border-(--color-border-muted) bg-(--color-card-background) p-5"
     >
-      <table className="w-full text-left text-base">
-        <thead>
-          <tr className="border-(--color-border-muted) border-b text-(--color-paragraph-text) text-sm">
-            <th scope="col" className="px-5 py-4 font-medium">
-              Line
-            </th>
-            <th scope="col" className="px-5 py-4 font-medium">
-              Amount
-            </th>
-            <th scope="col" className="px-5 py-4 font-medium">
-              Yours again afterwards
-            </th>
-          </tr>
-        </thead>
-        <tbody className="text-(--color-paragraph-text)">
-          {rows.map(({ label, amount, note }) => (
-            <tr key={label} className="border-(--color-border-muted) border-b">
-              <td className="px-5 py-4">{label}</td>
-              <td className="px-5 py-4 tabular-nums">{amount}</td>
-              <td className="px-5 py-4">{note}</td>
-            </tr>
-          ))}
-          <tr className="text-(--color-text-base)">
-            <td className="px-5 py-4 font-medium">Deposit</td>
-            <td className="px-5 py-4 font-medium text-lg tabular-nums">
-              {formatUsd(estimate.deposit)}
-            </td>
-            <td className="px-5 py-4">
-              {formatUsd(estimate.refundable)} comes back
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p className="px-5 py-4 text-(--color-paragraph-text) text-xs/relaxed">
-        The buffer is set aside, not spent, and you get back whatever is unused.
-        Treat your funded-until date as the date to act by rather than the date
-        service stops: if the balance runs out, providers can end the service
-        and keep the buffer. Depositing for longer is not a discount, it just
-        means fewer trips back.
+      <dl className="space-y-3 text-(--color-paragraph-text)">
+        {rows.map(({ label, amount, note }) => (
+          <div
+            key={label}
+            className="flex items-baseline justify-between gap-4"
+          >
+            <dt>
+              <span className="block text-sm">{label}</span>
+              <span className="block text-(--color-paragraph-text-subtle) text-xs">
+                {note}
+              </span>
+            </dt>
+            <dd className="shrink-0 text-sm tabular-nums">{amount}</dd>
+          </div>
+        ))}
+        <div className="flex items-baseline justify-between gap-4 border-(--color-border-muted) border-t pt-3 text-(--color-text-base)">
+          <dt className="font-medium">Deposit</dt>
+          <dd className="shrink-0 font-medium text-lg tabular-nums">
+            {formatUsd(estimate.deposit)}
+          </dd>
+        </div>
+      </dl>
+      <p className="text-(--color-paragraph-text) text-xs/relaxed">
+        {formatUsd(estimate.refundable)} of this comes back. The buffer is set
+        aside, not spent. Treat your funded-until date as the date to act by: if
+        the balance runs out, providers can end the service and keep the buffer.
       </p>
     </div>
   )

--- a/src/app/ipfs2filecoin/components/CostEstimator.tsx
+++ b/src/app/ipfs2filecoin/components/CostEstimator.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { Button } from '@filecoin-foundation/ui-filecoin/Button'
+import { Icon } from '@filecoin-foundation/ui-filecoin/Icon'
 import { Field, Input, Label, Select } from '@headlessui/react'
+import { CaretDownIcon } from '@phosphor-icons/react/dist/ssr'
+import { clsx } from 'clsx'
 import { usePlausible } from 'next-plausible'
-import { useId, useState } from 'react'
+import { type ChangeEvent, type ReactNode, useId, useState } from 'react'
 
 import {
   BUFFER_DAYS,
@@ -29,10 +32,11 @@ const DURATION_OPTIONS = [
 const fieldClassName =
   'focus:brand-outline block w-full rounded-lg border border-(--input-border-color) p-3 text-(--color-text-base) placeholder:text-(--input-placeholder-color)'
 
+const labelClassName =
+  'mb-1 inline-block font-medium text-(--color-text-base) text-sm'
+
 export function CostEstimator() {
   const volumeId = useId()
-  const unitId = useId()
-  const durationId = useId()
   const plausible = usePlausible()
 
   const [volume, setVolume] = useState('1')
@@ -67,12 +71,9 @@ export function CostEstimator() {
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 sm:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,2fr)]">
         <Field>
-          <Label
-            htmlFor={volumeId}
-            className="mb-1 inline-block font-medium text-(--color-text-base) text-sm"
-          >
+          <Label htmlFor={volumeId} className={labelClassName}>
             How much data
           </Label>
           <Input
@@ -87,44 +88,30 @@ export function CostEstimator() {
           />
         </Field>
 
-        <Field>
-          <Label
-            htmlFor={unitId}
-            className="mb-1 inline-block font-medium text-(--color-text-base) text-sm"
-          >
-            Unit
-          </Label>
-          <Select
-            id={unitId}
-            value={unit}
-            onChange={(event) => setUnit(event.target.value as VolumeUnit)}
-            className={fieldClassName}
-          >
-            <option value="GiB">GiB</option>
-            <option value="TiB">TiB</option>
-          </Select>
-        </Field>
+        <SelectField
+          label="Unit"
+          value={unit}
+          onChange={(event) => setUnit(event.target.value as VolumeUnit)}
+        >
+          <option value="GiB">GiB</option>
+          <option value="TiB">TiB</option>
+        </SelectField>
+        <p className="text-(--color-paragraph-text-subtle) text-sm sm:col-span-3">
+          Total across everything you are storing, not per CID. 1 TiB is 1,024
+          GiB.
+        </p>
 
-        <Field>
-          <Label
-            htmlFor={durationId}
-            className="mb-1 inline-block font-medium text-(--color-text-base) text-sm"
-          >
-            Funded for
-          </Label>
-          <Select
-            id={durationId}
-            value={days}
-            onChange={(event) => setDays(Number(event.target.value))}
-            className={fieldClassName}
-          >
-            {DURATION_OPTIONS.map(({ label, days: value }) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </Select>
-        </Field>
+        <SelectField
+          label="Funded for"
+          value={days}
+          onChange={(event) => setDays(Number(event.target.value))}
+        >
+          {DURATION_OPTIONS.map(({ label, days: value }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </SelectField>
       </div>
 
       <Button type="button" variant="primary" onClick={handleEstimate}>
@@ -148,6 +135,43 @@ export function CostEstimator() {
         it.
       </p>
     </div>
+  )
+}
+
+type SelectFieldProps = {
+  label: string
+  value: string | number
+  onChange: (event: ChangeEvent<HTMLSelectElement>) => void
+  children: ReactNode
+}
+
+/**
+ * A native select styled to match the inputs beside it. The browser's own arrow
+ * is replaced so the caret keeps the same inset as the field's text instead of
+ * sitting hard against the border.
+ */
+function SelectField({ label, value, onChange, children }: SelectFieldProps) {
+  const id = useId()
+
+  return (
+    <Field>
+      <Label htmlFor={id} className={labelClassName}>
+        {label}
+      </Label>
+      <div className="relative">
+        <Select
+          id={id}
+          value={value}
+          onChange={onChange}
+          className={clsx(fieldClassName, 'appearance-none pr-11')}
+        >
+          {children}
+        </Select>
+        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-(--color-paragraph-text)">
+          <Icon component={CaretDownIcon} size={20} />
+        </span>
+      </div>
+    </Field>
   )
 }
 
@@ -180,9 +204,9 @@ function EstimateBreakdown({ estimate }: { estimate: CostEstimate }) {
       aria-live="polite"
       className="overflow-x-auto rounded-xl border border-(--color-border-muted)"
     >
-      <table className="w-full text-left text-sm">
+      <table className="w-full text-left text-base">
         <thead>
-          <tr className="border-(--color-border-muted) border-b text-(--color-paragraph-text)">
+          <tr className="border-(--color-border-muted) border-b text-(--color-paragraph-text) text-sm">
             <th scope="col" className="px-5 py-4 font-medium">
               Line
             </th>
@@ -198,13 +222,13 @@ function EstimateBreakdown({ estimate }: { estimate: CostEstimate }) {
           {rows.map(({ label, amount, note }) => (
             <tr key={label} className="border-(--color-border-muted) border-b">
               <td className="px-5 py-4">{label}</td>
-              <td className="px-5 py-4 font-mono">{amount}</td>
+              <td className="px-5 py-4 tabular-nums">{amount}</td>
               <td className="px-5 py-4">{note}</td>
             </tr>
           ))}
           <tr className="text-(--color-text-base)">
             <td className="px-5 py-4 font-medium">Deposit</td>
-            <td className="px-5 py-4 font-medium font-mono text-lg">
+            <td className="px-5 py-4 font-medium text-lg tabular-nums">
               {formatUsd(estimate.deposit)}
             </td>
             <td className="px-5 py-4">

--- a/src/app/ipfs2filecoin/components/StepList.tsx
+++ b/src/app/ipfs2filecoin/components/StepList.tsx
@@ -14,7 +14,9 @@ type StepListProps = {
  */
 export function StepList({ steps }: StepListProps) {
   return (
-    <ol className="grid gap-10 md:grid-cols-2 md:gap-x-15">
+    // Four across on desktop so the sequence reads left to right in one pass.
+    // Two-up in between, where four columns would be too narrow for the copy.
+    <ol className="grid gap-10 sm:grid-cols-2 sm:gap-x-10 lg:grid-cols-4 lg:gap-x-8">
       {steps.map(({ number, title, description }) => (
         <li key={title} className="space-y-3">
           <span

--- a/src/app/ipfs2filecoin/components/StepList.tsx
+++ b/src/app/ipfs2filecoin/components/StepList.tsx
@@ -1,0 +1,34 @@
+import { Heading } from '@filecoin-foundation/ui-filecoin/Heading'
+
+import type { steps } from '../data/steps'
+
+type StepListProps = {
+  steps: typeof steps
+}
+
+/**
+ * Not the shared `Card`: its `title` is a plain string, so the step number could
+ * only ever be inlined as "01. Hand over the list". Lifting the number above the
+ * title and giving it the accent colour is what makes the section read as a
+ * sequence rather than four unrelated cards.
+ */
+export function StepList({ steps }: StepListProps) {
+  return (
+    <ol className="grid gap-10 md:grid-cols-2 md:gap-x-15">
+      {steps.map(({ number, title, description }) => (
+        <li key={title} className="space-y-3">
+          <span
+            aria-hidden="true"
+            className="block font-heading font-medium text-3xl text-brand-600 tabular-nums"
+          >
+            {number}
+          </span>
+          <Heading tag="h3" variant="card-heading">
+            {title}
+          </Heading>
+          <p className="text-(--color-paragraph-text)">{description}</p>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/src/app/ipfs2filecoin/constants/migration.ts
+++ b/src/app/ipfs2filecoin/constants/migration.ts
@@ -53,6 +53,20 @@ export const LLMS_TXT_URL = `${BASE_URL}${LLMS_TXT_PATH}`
 /** The one line a user hands to a coding agent. Copying it is signal, so it is tracked. */
 export const AGENT_PROMPT = `Migrate my IPFS data to Filecoin: read ${RUNBOOK_URL} and follow it. My CIDs are in cids.txt.`
 
+/**
+ * The same instruction with the user's own list inlined, so a checked list is
+ * something you can act on rather than just a count. Falls back to the
+ * cids.txt form when there is no list yet, which is also the right shape for
+ * lists too long to paste into a prompt.
+ */
+export function buildAgentPrompt(cids?: ReadonlyArray<string>): string {
+  if (!cids || cids.length === 0) {
+    return AGENT_PROMPT
+  }
+
+  return `Migrate my IPFS data to Filecoin: read ${RUNBOOK_URL} and follow it. My CIDs are:\n${cids.join('\n')}`
+}
+
 export const PLAUSIBLE_EVENTS = {
   cidListChecked: 'IPFS2Filecoin CID List Checked',
   estimateViewed: 'IPFS2Filecoin Estimate Viewed',

--- a/src/app/ipfs2filecoin/constants/seo.ts
+++ b/src/app/ipfs2filecoin/constants/seo.ts
@@ -1,5 +1,7 @@
+import { USD_PER_TIB_MONTH_PER_COPY } from './migration'
+import { formatUsd } from '../utils/estimate-cost'
+
 export const IPFS2FILECOIN_SEO = {
   title: 'IPFS to Filecoin | Move Your Pinned Data Without Changing Your CIDs',
-  description:
-    'Move pinned IPFS data to Filecoin warm storage. Same CIDs, $2.50 per TiB per month per copy, and an onchain receipt you can verify yourself.',
+  description: `Move pinned IPFS data to Filecoin warm storage. Same CIDs, ${formatUsd(USD_PER_TIB_MONTH_PER_COPY)} per TiB per month per copy, and an onchain receipt you can verify yourself.`,
 } as const

--- a/src/app/ipfs2filecoin/data/pricing-comparison.ts
+++ b/src/app/ipfs2filecoin/data/pricing-comparison.ts
@@ -1,7 +1,16 @@
+import { COPIES } from '../constants/migration'
 import { formatUsd, USD_PER_TB_MONTH } from '../utils/estimate-cost'
 
 export type PricingRow = {
   service: string
+  /**
+   * The qualifier under the provider name: which plan the rate comes from, or
+   * what the Filecoin figure covers. Split out from the service so the provider
+   * is what you compare on and the tier name stays secondary: at one size they
+   * competed, and two Pinata tiers read as two unrelated vendors. Every row
+   * carries one so the rows are the same height.
+   */
+  detail: string
   storagePerTbMonth: string
   egress: string
   highlighted?: boolean
@@ -15,22 +24,32 @@ export type PricingRow = {
 export const pricingComparison: Array<PricingRow> = [
   {
     service: 'Filecoin Warm Storage',
+    detail: `${COPIES} copies included`,
     storagePerTbMonth: formatUsd(USD_PER_TB_MONTH),
-    egress: 'IPFS gateway read path',
+    /**
+     * Deliberately not a price and deliberately not "free". Reads happen by CID
+     * over public IPFS gateways, which this service does not meter. Fast
+     * delivery through Filecoin Beam is a separate, paid product, so any claim
+     * of zero egress cost here would be wrong.
+     */
+    egress: 'Read by CID from any IPFS gateway',
     highlighted: true,
   },
   {
-    service: 'Filebase, Pro overage',
+    service: 'Filebase',
+    detail: 'Pro plan overage',
     storagePerTbMonth: '$15.00',
     egress: '$0.015 / GB',
   },
   {
-    service: 'Pinata, Fiesta overage',
+    service: 'Pinata',
+    detail: 'Fiesta plan overage',
     storagePerTbMonth: '$35.00',
     egress: '$0.080 / GB',
   },
   {
-    service: 'Pinata, Picnic overage',
+    service: 'Pinata',
+    detail: 'Picnic plan overage',
     storagePerTbMonth: '$70.00',
     egress: '$0.100 / GB',
   },

--- a/src/app/ipfs2filecoin/data/reasons.ts
+++ b/src/app/ipfs2filecoin/data/reasons.ts
@@ -1,22 +1,33 @@
+import {
+  CurrencyDollarIcon,
+  FingerprintIcon,
+  SealCheckIcon,
+  WalletIcon,
+} from '@phosphor-icons/react/dist/ssr'
+
 export const reasons = [
   {
     title: 'Your CIDs do not change',
     description:
       'Nothing is re-chunked. Every CID stays byte-identical and keeps resolving from any public IPFS gateway, so existing links, IPNS names, and NFT metadata keep working exactly as they do today.',
+    icon: FingerprintIcon,
   },
   {
     title: 'A fraction of pinning-service pricing',
     description:
       '$2.50 per TiB per month per copy, two copies by default. You pay storage providers directly, streamed per epoch, with no plan tiers and no minimum commitment.',
+    icon: CurrencyDollarIcon,
   },
   {
     title: 'Proof, not a dashboard',
     description:
       'Storage providers prove possession onchain on a schedule. You get a receipt with transaction links, and you can verify any piece yourself at any time without asking anyone.',
+    icon: SealCheckIcon,
   },
   {
     title: 'Your wallet owns it, not an account',
     description:
       'No signup and no vendor account to lose. The data set belongs to your wallet address and payment streams from your wallet straight to the providers. Reading your data never depends on your key, so the content stays reachable either way.',
+    icon: WalletIcon,
   },
 ] as const

--- a/src/app/ipfs2filecoin/data/reasons.ts
+++ b/src/app/ipfs2filecoin/data/reasons.ts
@@ -5,6 +5,9 @@ import {
   WalletIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
+import { USD_PER_TIB_MONTH_PER_COPY } from '../constants/migration'
+import { formatUsd } from '../utils/estimate-cost'
+
 export const reasons = [
   {
     title: 'Your CIDs do not change',
@@ -14,8 +17,7 @@ export const reasons = [
   },
   {
     title: 'A fraction of pinning-service pricing',
-    description:
-      '$2.50 per TiB per month per copy, two copies by default. You pay storage providers directly, streamed per epoch, with no plan tiers and no minimum commitment.',
+    description: `${formatUsd(USD_PER_TIB_MONTH_PER_COPY)} per TiB per month per copy, two copies by default. You pay storage providers directly, streamed per epoch, with no plan tiers and no minimum commitment.`,
     icon: CurrencyDollarIcon,
   },
   {

--- a/src/app/ipfs2filecoin/page.tsx
+++ b/src/app/ipfs2filecoin/page.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@filecoin-foundation/ui-filecoin/Button'
 import { Card } from '@filecoin-foundation/ui-filecoin/Card'
 import { CardGrid } from '@filecoin-foundation/ui-filecoin/CardGrid'
-import { Container } from '@filecoin-foundation/ui-filecoin/Container'
 import { Heading } from '@filecoin-foundation/ui-filecoin/Heading'
 import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
 import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
@@ -22,6 +21,7 @@ import { AgentPrompt } from './components/AgentPrompt'
 import { CidListChecker } from './components/CidListChecker'
 import { ComparisonTable } from './components/ComparisonTable'
 import { CostEstimator } from './components/CostEstimator'
+import { StepList } from './components/StepList'
 import { COORDINATION_VOLUME_LABEL, RUNBOOK_PATH } from './constants/migration'
 import { IPFS2FILECOIN_SEO } from './constants/seo'
 import { faqs } from './data/faqs'
@@ -32,6 +32,14 @@ import { generateStructuredData } from './utils/generate-structured-data'
 
 const ghostOnDark =
   '!border-zinc-50/40 !bg-transparent hover:!border-zinc-50 hover:!bg-zinc-50/5'
+
+/**
+ * `ExternalTextLink` sizes its arrow for button-style links: a fixed 16px glyph
+ * set `ml-1` off the label. Inside a 14px paragraph that reads as oversized and
+ * detached, so pull it in and scale it to the text. Fix belongs upstream in
+ * ui-filecoin; this keeps the footnote legible until then.
+ */
+const inlineExternalLink = '[&>span]:ml-0.5 [&_svg]:size-3.5'
 
 export default function IpfsToFilecoin() {
   return (
@@ -49,11 +57,9 @@ export default function IpfsToFilecoin() {
           title="Move your pinned IPFS data to Filecoin"
           description="Same CIDs, a fraction of what pinning services charge, and an onchain receipt you can verify yourself."
         />
-        <Container>
-          <div className="mt-10">
-            <CidListChecker />
-          </div>
-        </Container>
+        <div className="mt-10">
+          <CidListChecker />
+        </div>
       </PageSection>
 
       <PageSection backgroundVariant="gray">
@@ -63,12 +69,13 @@ export default function IpfsToFilecoin() {
           description="Your data keeps working the way it does today. What changes is the price, the proof, and who owns it."
         >
           <CardGrid as="ul" variant="lgTwoWide">
-            {reasons.map(({ title, description }) => (
+            {reasons.map(({ title, description, icon }) => (
               <Card
                 key={title}
                 as="li"
                 title={title}
                 description={description}
+                icon={icon}
               />
             ))}
           </CardGrid>
@@ -88,11 +95,17 @@ export default function IpfsToFilecoin() {
               Filecoin Warm Storage is $2.50 per TiB per month per copy at two
               copies. Other rates are published list overage rates as of 27 July
               2026, from{' '}
-              <ExternalTextLink href="https://filebase.com/pricing/">
+              <ExternalTextLink
+                className={inlineExternalLink}
+                href="https://filebase.com/pricing/"
+              >
                 Filebase
               </ExternalTextLink>{' '}
               and{' '}
-              <ExternalTextLink href="https://pinata.cloud/pricing">
+              <ExternalTextLink
+                className={inlineExternalLink}
+                href="https://pinata.cloud/pricing"
+              >
                 Pinata
               </ExternalTextLink>
               . Filecoin includes two replicas; the other services do not
@@ -103,20 +116,18 @@ export default function IpfsToFilecoin() {
       </PageSection>
 
       <PageSection backgroundVariant="light" paddingVariant="topNone">
-        <Container>
-          <div className="max-w-4xl space-y-6">
-            <Heading tag="h2" variant="card-heading">
-              Estimate your deposit
-            </Heading>
-            <p className="text-(--color-paragraph-text)">
-              Storage is charged continuously while your data sits there, so you
-              deposit for a period rather than paying a monthly bill. Enter
-              roughly how much you are holding and how long you want to be
-              covered. This runs in your browser and nothing is sent anywhere.
-            </p>
-            <CostEstimator />
-          </div>
-        </Container>
+        <div className="max-w-4xl space-y-6">
+          <Heading tag="h2" variant="card-heading">
+            Estimate your deposit
+          </Heading>
+          <p className="text-(--color-paragraph-text)">
+            Storage is charged continuously while your data sits there, so you
+            deposit for a period rather than paying a monthly bill. Enter
+            roughly how much you are holding and how long you want to be
+            covered. This runs in your browser and nothing is sent anywhere.
+          </p>
+          <CostEstimator />
+        </div>
       </PageSection>
 
       <PageSection backgroundVariant="gray">
@@ -125,16 +136,7 @@ export default function IpfsToFilecoin() {
           title="How it works"
           description="Four steps, and the first two are free."
         >
-          <CardGrid as="ul" variant="smTwoLgThreeWider">
-            {steps.map(({ number, title, description }) => (
-              <Card
-                key={title}
-                as="li"
-                title={`${number}. ${title}`}
-                description={description}
-              />
-            ))}
-          </CardGrid>
+          <StepList steps={steps} />
         </SectionContent>
       </PageSection>
 
@@ -144,8 +146,8 @@ export default function IpfsToFilecoin() {
           title="Nobody should migrate an archive by clicking"
           description="Real migrations run unattended, so that is the path this is built around. Check a list for free, get your account funded in one pass, then hand the work to your agent or to us."
         >
-          <div className="grid gap-8 lg:grid-cols-2">
-            <div id="agent" className="scroll-mt-24 space-y-4">
+          <div className="grid gap-10 lg:grid-cols-3 lg:gap-15">
+            <div id="agent" className="scroll-mt-24 space-y-4 lg:col-span-2">
               <Heading tag="h3" variant="card-heading">
                 Ask your agent to do it
               </Heading>
@@ -167,7 +169,7 @@ export default function IpfsToFilecoin() {
               <AgentPrompt source="agent-door" />
             </div>
 
-            <div className="space-y-4">
+            <div className="h-fit space-y-4 rounded-xl border border-(--color-border-base) bg-(--color-card-background) p-6">
               <Heading tag="h3" variant="card-heading">
                 Talk to us
               </Heading>
@@ -195,7 +197,7 @@ export default function IpfsToFilecoin() {
           title="What this does not do"
           description="The things worth knowing up front, so nothing surprises you halfway through a run."
         >
-          <dl className="divide-y divide-(--color-border-muted) border-(--color-border-muted) border-t">
+          <dl className="max-w-5xl divide-y divide-(--color-border-muted) border-(--color-border-muted) border-t">
             {limits.map(({ title, description }) => (
               <div
                 key={title}

--- a/src/app/ipfs2filecoin/page.tsx
+++ b/src/app/ipfs2filecoin/page.tsx
@@ -2,11 +2,13 @@ import { Button } from '@filecoin-foundation/ui-filecoin/Button'
 import { Card } from '@filecoin-foundation/ui-filecoin/Card'
 import { CardGrid } from '@filecoin-foundation/ui-filecoin/CardGrid'
 import { Heading } from '@filecoin-foundation/ui-filecoin/Heading'
+import { Icon } from '@filecoin-foundation/ui-filecoin/Icon'
 import { PageHeader } from '@filecoin-foundation/ui-filecoin/PageHeader'
 import { PageSection } from '@filecoin-foundation/ui-filecoin/PageSection'
 import { SectionContent } from '@filecoin-foundation/ui-filecoin/SectionContent'
 import { ExternalTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/ExternalTextLink'
 import { SmartTextLink } from '@filecoin-foundation/ui-filecoin/TextLink/SmartTextLink'
+import { WarningCircleIcon } from '@phosphor-icons/react/dist/ssr'
 import type { Metadata } from 'next'
 
 import { Faq } from '@/components/Faq'
@@ -50,17 +52,33 @@ export default function IpfsToFilecoin() {
 
       <Navigation backgroundVariant="dark" />
 
-      <PageSection backgroundVariant="dark">
-        <PageHeader
-          centered
-          variant="highContrast"
-          title="Move your pinned IPFS data to Filecoin"
-          description="Same CIDs, a fraction of what pinning services charge, and an onchain receipt you can verify yourself."
-        />
-        <div className="mt-10">
-          <CidListChecker />
+      {/*
+        Full-bleed backdrop behind the hero, following the homepage pattern: an
+        `isolate relative` wrapper, an `absolute inset-0 -z-10` layer that spans
+        edge to edge rather than the padded container, and `transparentDark` on
+        the section so the layer shows through while text keeps its dark-section
+        tokens. The base stays zinc-950 as before; a faint brand glow along the
+        bottom lifts it just enough to read as lit rather than flat black, and
+        carries the eye toward the section that follows. The tint is the
+        --color-brand-500 token (the primary blue), mixed down to 12% so it reads
+        as light on the surface, not a coloured panel.
+      */}
+      <div className="isolate relative">
+        <div aria-hidden className="absolute inset-0 -z-10 bg-zinc-950">
+          <div className="absolute inset-x-0 bottom-0 h-144 bg-[radial-gradient(60%_100%_at_50%_100%,color-mix(in_oklab,var(--color-brand-500)_12%,transparent),transparent_70%)]" />
         </div>
-      </PageSection>
+        <PageSection backgroundVariant="transparentDark">
+          <PageHeader
+            centered
+            variant="highContrast"
+            title="Move your pinned IPFS data to Filecoin"
+            description="Same CIDs, a fraction of what pinning services charge, and an onchain receipt you can verify yourself."
+          />
+          <div className="mt-10">
+            <CidListChecker />
+          </div>
+        </PageSection>
+      </div>
 
       <PageSection backgroundVariant="gray">
         <SectionContent
@@ -74,7 +92,12 @@ export default function IpfsToFilecoin() {
                 key={title}
                 as="li"
                 title={title}
-                description={description}
+                // Card sets descriptions at text-xl/7; these reason blurbs run
+                // long and read heavier than the titles at that size. Stepped
+                // down per-instance so the shared Card stays untouched.
+                description={
+                  <span className="text-base/relaxed">{description}</span>
+                }
                 icon={icon}
               />
             ))}
@@ -88,46 +111,57 @@ export default function IpfsToFilecoin() {
           title="What it costs"
           description="Pinning services bundle an allowance into a monthly plan, then charge per gigabyte past it. Once you are past the allowance, which anyone migrating a real archive already is, the overage rate is your real cost."
         >
-          <div className="space-y-6">
-            <ComparisonTable />
+          {/*
+            The comparison and the estimator answer one question between them:
+            the table is the market rate, the card prices it for your own data.
+            Paired side by side at lg so they read as two halves of "what it
+            costs"; stacked below that, where a 2fr/1fr split leaves the table
+            too narrow to hold its columns.
+          */}
+          <div className="grid gap-8 lg:grid-cols-3 lg:items-start">
+            <div className="space-y-6 lg:col-span-2">
+              <ComparisonTable />
 
-            <p className="text-(--color-paragraph-text) text-sm/relaxed">
-              Filecoin Warm Storage is $2.50 per TiB per month per copy at two
-              copies. Other rates are published list overage rates as of 27 July
-              2026, from{' '}
-              <ExternalTextLink
-                className={inlineExternalLink}
-                href="https://filebase.com/pricing/"
-              >
-                Filebase
-              </ExternalTextLink>{' '}
-              and{' '}
-              <ExternalTextLink
-                className={inlineExternalLink}
-                href="https://pinata.cloud/pricing"
-              >
-                Pinata
-              </ExternalTextLink>
-              . Filecoin includes two replicas; the other services do not
-              publish a replication factor, so the comparison is conservative.
-            </p>
+              <p className="text-(--color-paragraph-text) text-sm/relaxed">
+                Filecoin Warm Storage is $2.50 per TiB per month per copy at two
+                copies. Other rates are published list overage rates as of 27
+                July 2026, from{' '}
+                <ExternalTextLink
+                  className={inlineExternalLink}
+                  href="https://filebase.com/pricing/"
+                >
+                  Filebase
+                </ExternalTextLink>{' '}
+                and{' '}
+                <ExternalTextLink
+                  className={inlineExternalLink}
+                  href="https://pinata.cloud/pricing"
+                >
+                  Pinata
+                </ExternalTextLink>
+                . Filecoin includes two replicas; the other services do not
+                publish a replication factor, so the comparison is conservative.
+              </p>
+            </div>
+
+            <div
+              id="estimate"
+              className="scroll-mt-24 rounded-xl border border-(--color-border-muted) bg-(--color-card-background-hover) p-6"
+            >
+              <Heading tag="h3" variant="card-heading">
+                Estimate your deposit
+              </Heading>
+              <p className="mt-2 text-(--color-paragraph-text) text-sm/relaxed">
+                Storage is prepaid for a period rather than billed monthly.
+                Enter roughly how much you hold and for how long; it runs in
+                your browser.
+              </p>
+              <div className="mt-6">
+                <CostEstimator />
+              </div>
+            </div>
           </div>
         </SectionContent>
-      </PageSection>
-
-      <PageSection backgroundVariant="light" paddingVariant="topNone">
-        <div className="max-w-4xl space-y-6">
-          <Heading tag="h2" variant="card-heading">
-            Estimate your deposit
-          </Heading>
-          <p className="text-(--color-paragraph-text)">
-            Storage is charged continuously while your data sits there, so you
-            deposit for a period rather than paying a monthly bill. Enter
-            roughly how much you are holding and how long you want to be
-            covered. This runs in your browser and nothing is sent anywhere.
-          </p>
-          <CostEstimator />
-        </div>
       </PageSection>
 
       <PageSection backgroundVariant="gray">
@@ -146,7 +180,14 @@ export default function IpfsToFilecoin() {
           title="Nobody should migrate an archive by clicking"
           description="Real migrations run unattended, so that is the path this is built around. Check a list for free, get your account funded in one pass, then hand the work to your agent or to us."
         >
-          <div className="grid gap-10 lg:grid-cols-3 lg:gap-15">
+          {/*
+            No panels. Boxing both columns stacked three nested borders in the
+            left one: panel, then code block, then a warning box inside it. One
+            hairline between the columns does the same separating work, and the
+            code block stays the only bordered thing because it is a surface you
+            copy from rather than a container.
+          */}
+          <div className="grid gap-10 lg:grid-cols-3 lg:gap-14">
             <div id="agent" className="scroll-mt-24 space-y-4 lg:col-span-2">
               <Heading tag="h3" variant="card-heading">
                 Ask your agent to do it
@@ -159,17 +200,34 @@ export default function IpfsToFilecoin() {
                 </SmartTextLink>
                 , works through your list, and reports back what landed.
               </p>
-              <p className="text-(--color-paragraph-text)">
-                It signs from a key you provide, and a key that can sign on your
-                account can draw against its balance, so your deposit is the
-                ceiling. Use a wallet you keep for this purpose, holding what
-                this migration needs and nothing else. Never give a main
-                wallet&apos;s key to something running unattended.
-              </p>
+
+              {/* The action ahead of the caveat: this is what people came for. */}
               <AgentPrompt source="agent-door" />
+
+              {/*
+                Marked with an icon and a bolded rule rather than a box. This is
+                the one thing here that can cost someone real money, so it
+                cannot read as a third grey paragraph, but it does not need a
+                container to say so.
+              */}
+              <div className="flex gap-2.5">
+                <span className="mt-0.5 shrink-0 text-(--color-brand-error)">
+                  <Icon component={WarningCircleIcon} size={16} />
+                </span>
+                <p className="text-(--color-paragraph-text) text-sm/relaxed">
+                  It signs from a key you provide, and a key that can sign on
+                  your account can draw against its balance, so your deposit is
+                  the ceiling. Use a wallet you keep for this purpose, holding
+                  what this migration needs and nothing else.{' '}
+                  <strong className="font-medium text-(--color-text-base)">
+                    Never give a main wallet&apos;s key to something running
+                    unattended.
+                  </strong>
+                </p>
+              </div>
             </div>
 
-            <div className="h-fit space-y-4 rounded-xl border border-(--color-border-base) bg-(--color-card-background) p-6">
+            <div className="h-fit space-y-4 lg:border-(--color-border-muted) lg:border-l lg:pl-14">
               <Heading tag="h3" variant="card-heading">
                 Talk to us
               </Heading>
@@ -179,13 +237,18 @@ export default function IpfsToFilecoin() {
                 {COORDINATION_VOLUME_LABEL}. That is coordination, not a
                 ceiling: the agent path has no cap on how many CIDs it migrates.
               </p>
-              <Button
-                href={PATHS.CONTACT.path}
-                variant="ghost"
-                className={ghostOnDark}
-              >
-                Tell us about your data
-              </Button>
+              {/* Padding rather than a margin: the parent's `space-y` already
+                  owns each child's margin-top, so this adds to it instead of
+                  fighting it. */}
+              <div className="pt-4">
+                <Button
+                  href={PATHS.CONTACT.path}
+                  variant="ghost"
+                  className={ghostOnDark}
+                >
+                  Tell us about your data
+                </Button>
+              </div>
             </div>
           </div>
         </SectionContent>

--- a/src/app/ipfs2filecoin/page.tsx
+++ b/src/app/ipfs2filecoin/page.tsx
@@ -24,12 +24,17 @@ import { CidListChecker } from './components/CidListChecker'
 import { ComparisonTable } from './components/ComparisonTable'
 import { CostEstimator } from './components/CostEstimator'
 import { StepList } from './components/StepList'
-import { COORDINATION_VOLUME_LABEL, RUNBOOK_PATH } from './constants/migration'
+import {
+  COORDINATION_VOLUME_LABEL,
+  RUNBOOK_PATH,
+  USD_PER_TIB_MONTH_PER_COPY,
+} from './constants/migration'
 import { IPFS2FILECOIN_SEO } from './constants/seo'
 import { faqs } from './data/faqs'
 import { limits } from './data/limits'
 import { reasons } from './data/reasons'
 import { steps } from './data/steps'
+import { formatUsd } from './utils/estimate-cost'
 import { generateStructuredData } from './utils/generate-structured-data'
 
 const ghostOnDark =
@@ -123,9 +128,9 @@ export default function IpfsToFilecoin() {
               <ComparisonTable />
 
               <p className="text-(--color-paragraph-text) text-sm/relaxed">
-                Filecoin Warm Storage is $2.50 per TiB per month per copy at two
-                copies. Other rates are published list overage rates as of 27
-                July 2026, from{' '}
+                Filecoin Warm Storage is {formatUsd(USD_PER_TIB_MONTH_PER_COPY)}{' '}
+                per TiB per month per copy at two copies. Other rates are
+                published list overage rates as of 27 July 2026, from{' '}
                 <ExternalTextLink
                   className={inlineExternalLink}
                   href="https://filebase.com/pricing/"

--- a/src/app/ipfs2filecoin/utils/pluralize.ts
+++ b/src/app/ipfs2filecoin/utils/pluralize.ts
@@ -1,0 +1,8 @@
+/** Shared by the checker's live readout and its verdict, so the two agree. */
+export function pluralize(
+  count: number,
+  singular: string,
+  plural = `${singular}s`,
+) {
+  return count === 1 ? singular : plural
+}

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -22,7 +22,7 @@ function AccordionItem({
     <AccordionPrimitive.Item
       data-slot="accordion-item"
       className={clsx(
-        'group/accordion border-b last:border-b-0 py-4',
+        'group/accordion border-(--color-border-base) border-b last:border-b-0 py-4',
         className,
       )}
       {...props}
@@ -46,7 +46,7 @@ function AccordionTrigger({
         {...props}
       >
         {children}
-        <span className="transition-transform duration-200 group-data-[state=open]/accordion:rotate-180 text-zinc-200">
+        <span className="transition-transform duration-200 group-data-[state=open]/accordion:rotate-180 text-(--color-text-base)">
           <Icon component={CaretDownIcon} color="inherit" />
         </span>
       </AccordionPrimitive.Trigger>
@@ -62,7 +62,7 @@ function AccordionContent({
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"
-      className="data-[state=closed]:animate-slide-up data-[state=open]:animate-slide-down overflow-hidden text-zinc-300"
+      className="data-[state=closed]:animate-slide-up data-[state=open]:animate-slide-down overflow-hidden text-(--color-paragraph-text)"
       {...props}
     >
       <div className={clsx('pb-4', className)}>{children}</div>

--- a/src/components/Faq.tsx
+++ b/src/components/Faq.tsx
@@ -21,7 +21,7 @@ export function Faq({ questions }: FaqProps) {
   return (
     <div className="max-w-4xl">
       <SectionContent headingTag="h2" title="Frequently asked questions">
-        <Accordion type="single" collapsible className="divide-white/20">
+        <Accordion type="single" collapsible>
           {questions.map(({ question, answer }) => {
             return (
               <Accordion.Item key={question} value={question} className="py-4">


### PR DESCRIPTION
## 📝 Description

Design review follow-ups for `/ipfs2filecoin`, from a walkthrough of the page with @filipagr on 31 July, plus two rounds of polish since.

This targets `feat/ipfs2filecoin-landing-page` rather than `main` on purpose, so it feeds #346 instead of competing with it. Merging here means #346 carries the polish through to `main` as one piece.

Filipa's overall read was that the structure, content and calls to action are right — opening with "paste your CIDs" instead of a wall of reading is the correct choice. Almost everything below is layout and type hierarchy, plus one genuine functional gap and one drift risk.

- **Type:** Bug fix

**Two things to know before reviewing:**

1. **This currently conflicts with the base**, in `src/app/ipfs2filecoin/page.tsx`. The base branch has gained four commits this head doesn't have (`bc84838` runbook rewrite for the direct-upload flow, `abbe4ca` flat data set fee charged once, `b67a9fb` unpin the CLI, `55dcabd` re-verify competitor rates), and they touch the same file as the layout rework. `CostEstimator.tsx`, `constants/migration.ts` and `data/pricing-comparison.ts` all auto-merge; only `page.tsx` needs hand-resolving.
2. **The diff includes changes that aren't mine.** This branch merged `FilOzone:main`, and the base is behind `main`, so the diff against the base also shows `.github/CODEOWNERS` (#349), the `@filoz/synapse-sdk` 1.1.1 bump (#348), and the temporary hiding of the Service Providers page with its redirect in `next.config.ts` (#347). Those aren't part of this work and will disappear once the base catches up with `main`. Reviewable scope is `src/app/ipfs2filecoin/**` plus `src/components/{Accordion,Faq}.tsx` and `.gitignore`.

## 🛠️ Key Changes

Three rounds, each commit scoped to one concern and independently revertable.

### Round 1 — design review follow-ups (31 July)

**`fix(faq)` — accordion dividers and chevrons were invisible.** `Faq` hardcoded `divide-white/20` and `Accordion` hardcoded `text-zinc-200`/`text-zinc-300`. All three assume a dark background, which held while the homepage was the only consumer; this page mounts the FAQ on a gray section, where they disappear. Now uses the `--color-border-base` / `--color-text-base` / `--color-paragraph-text` tokens, which already flip off the `.light-section` / `.dark-section` class `Section` sets — so no `isDark` branching was needed. Moving the colour onto the item rather than the parent also fixes the first divider: `divide-*` targets every child after the first, so item one's border was falling back to `currentColor` and rendering at full brightness on dark.

**`fix(ipfs2filecoin)` — layout and type hierarchy.**
- The hero and "Estimate your deposit" sat 60px inset from their siblings: `PageSection` already wraps children in a `Container` and `page.tsx` nested a second one, doubling the horizontal padding.
- Unit/Funded-for selects had the native arrow jammed against the border with a cavern between it and the value. Local `SelectField` goes `appearance-none` with a Phosphor caret inset to match the field's text.
- Both tables move off `text-sm` to `text-base`, service names to `text-lg`.
- Monospace figures dropped for the body font with `tabular-nums`.
- Step numbers sit above each title in the accent colour, which needed a new `StepList` — the shared `Card` types `title` as a plain string, so the number could otherwise only be inlined as "01. Hand over the list".
- Reason cards take Phosphor icons, following how `agents/` and `warm-storage-service/` already pass icons to `Card`.
- The agent column takes two thirds with "Talk to us" as a one third call-out.
- "What this does not do" constrained to `max-w-5xl` — lines ran past 15 words at desktop.

**`feat(ipfs2filecoin)` — a checked CID list now produces something.** `parseCidList` already validated, deduped and stripped gateway prefixes, but the verdict reported only a count, so the top of the page had no purpose — you still built `cids.txt` by hand. The prompt was in fact only offered on the over-cap branch, so the one outcome that succeeded was the one with no output. A checked list now yields the agent prompt with your own CIDs inlined via `buildAgentPrompt`, plus a `cids.txt` download of the cleaned list. `AGENT_PROMPT` stays as the fallback for the empty and over-cap cases, where pointing at a file is the right shape rather than inlining hundreds of lines. The instruction to "estimate what they cost to store below" is gone: a check reads the CIDs, not the bytes behind them, so it cannot price anything on its own.

**`chore`** — ignores `CLAUDE.md` and a local `todo.md`.

### Round 2 — @filipagr's polish (#1, 3 August)

**CID checker becomes one input surface.** Label, textarea and action fold into a single bordered panel with a live "X of Y lines are CIDs" readout and a Cmd/Ctrl+Enter shortcut. The verdict moves into its own `CidListVerdict` component with an icon per outcome, and `pluralize` is extracted so the readout and the verdict agree.

**Pricing table compares providers, not plan names.** Each row gains a detail sub-line so the provider is what you compare on and the plan tier stays secondary, and rows are keyed by provider *plus* tier now that two Pinata tiers share a name. Below `md` the three columns don't fit, so each provider becomes a stacked card; the full table returns at `md`.

**Estimator pairs with the table.** It moves into a companion card beside the comparison table — the table is the market rate, the card prices it for your data — at `lg:grid-cols-3` with the table on two columns and the estimator on one, its two inputs side by side and a compact stacked result that fits the narrow column. Also: a faint brand glow along the bottom of the hero (`--color-brand-500` mixed to 12%, so it reads as light on the surface rather than a coloured panel), reason-card and agent-warning copy stepped down a size, and "How it works" four across at `lg` (2×2 from `sm`).

### Round 3 — kill the hardcoded rate (#2, 5 August)

`$2.50` was restated as a literal in the rate footnote, one reason card, and the SEO description, so all three could silently drift from the comparison table and estimator, which already derive from the constant. All now go through `formatUsd(USD_PER_TIB_MONTH_PER_COPY)`.

## 📌 To-Do Before Merging

- [ ] **Resolve the conflict in `page.tsx`** against the base's four newer commits. Worth doing as a merge of the base into this branch rather than a rebase, since the history is shared with @filipagr.
- [ ] @filipagr — the monospace figures were **dropped** rather than resized. The reported problem was numbers looking larger than the service names beside them; that was a typeface illusion rather than a size difference, so matching the typeface removes it at the root while `tabular-nums` keeps the columns aligned. Still the most debatable call here, and easy to revert.
- [ ] @filipagr — `Accordion`/`Faq` are shared, so **the homepage FAQ changes too**: chevron `zinc-200` → `zinc-50`, body `zinc-300` → `zinc-400`. Both now match the site's own tokens, but worth eyeballing since it's outside this page's scope.
- [ ] The external-link arrow beside Filebase/Pinata is fixed with a **local override** in `page.tsx`. It's sized for button text inside `ExternalTextLink` in `ui-filecoin`, so the real fix belongs upstream — worth a follow-up issue.

Closed since the original review: the hero background treatment, now handled by the brand glow rather than a produced asset; and table whitespace, which the responsive stacked cards and settled type sizes addressed.

Still **not** attempted, both needing a call rather than code:

- The optional illustration beside "Nobody should migrate an archive by clicking" — Filipa's crowding caution stands.
- Resolving a CID to its actual byte size, so the estimate reflects the real list rather than a number the user guesses. Needs backend capability and is a separate conversation.

## 🧪 How to Test

- **Setup:** `nvm use && npm install && npm run dev`, then open `/ipfs2filecoin`.
- **Steps to Test:**
  1. **CID check.** Paste a deliberately messy list into the hero panel — a bare CID, an `https://ipfs.io/ipfs/…` gateway URL, a duplicate, and a junk line. Watch the "X of Y lines are CIDs" readout as you type, then submit with Cmd/Ctrl+Enter rather than the button.
  2. **Cost section.** At `lg` the comparison table should occupy two thirds with the "Estimate your deposit" card beside it on one third, tops aligned. Narrow the window: the card drops below the table, and below `md` the table itself becomes one stacked card per provider.
  3. **Pricing rows.** Both Pinata tiers should render distinctly, each with its plan tier as a sub-line under the provider name.
  4. **How it works.** Four across at `lg`, 2×2 from `sm`, step numbers above each title in the accent colour.
  5. **FAQ.** Dividers and chevrons should be clearly visible against the gray section, including the divider above the *first* item. Compare with the homepage FAQ on its dark section.
  6. **Hero.** A faint blue lift along the bottom edge, carrying into the section below — not a visible panel edge.
- **Expected Results:** step 1 resolves to the unique CIDs with the gateway prefix stripped, reports both the skipped line and the removed duplicate, and renders a prompt containing your actual CIDs plus a `Download cids.txt` link.
- **Verified:** `npm run build` (TypeScript, twoslash'd Synapse snippet, all 25 routes) passes at `2a8113a`, the PR #1 merge. The head has since taken #2 and a `main` merge and hasn't been rebuilt locally — the conflict resolution will need a fresh build anyway.

## 📸 Screenshots

Verified in-browser at 1284px. Not attached here — CLI-created PR. Happy to add before/afters for the FAQ, the steps grid, the table/estimator pairing and the CID-check flow if useful.

## 🔖 Resources

- Design review walkthrough with @filipagr, 31 July 2026
- Polish round: #1 (fork-local), rate derivation: #2 (fork-local)
- Builds on #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
