### PR TITLE
ci: format synced contract addresses

### DIFF
--- a/.github/workflows/sync-contract-addresses.yml
+++ b/.github/workflows/sync-contract-addresses.yml
@@ -47,6 +47,10 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: npx tsx scripts/sync-contract-addresses.ts
 
+      - name: Format synced contract addresses
+        if: steps.check.outputs.changed == 'true'
+        run: npx biome format --write src/config/deployments.json
+
       - name: Create Pull Request
         if: steps.check.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
## Summary

- format `src/config/deployments.json` after the scheduled sync updates it
- run the formatter only when the sync check reports changes
- ensure automated contract-address PRs pass the repository's Biome formatting check

## Root cause

The sync script writes upstream JSON with `JSON.stringify(..., null, 2)`. Biome may compact short arrays according to the repository's JSON formatting rules, so newly generated files can differ from `biome format` output and fail the Code quality workflow.
